### PR TITLE
Add: Expose NodeOptions init + properties publicly

### DIFF
--- a/Sources/LibP2PKadDHT/Networking/Networking.swift
+++ b/Sources/LibP2PKadDHT/Networking/Networking.swift
@@ -70,15 +70,15 @@ extension KadDHT {
     }
 
     public struct NodeOptions {
-        let connectionTimeout: TimeAmount
-        let maxConcurrentConnections: Int
-        let bucketSize: Int
-        let maxPeers: Int
-        let maxKeyValueStoreSize: Int
-        let maxProviderStoreSize: Int
-        let supportLocalNetwork: Bool
+        public let connectionTimeout: TimeAmount
+        public let maxConcurrentConnections: Int
+        public let bucketSize: Int
+        public let maxPeers: Int
+        public let maxKeyValueStoreSize: Int
+        public let maxProviderStoreSize: Int
+        public let supportLocalNetwork: Bool
 
-        init(
+        public init(
             connectionTimeout: TimeAmount = .seconds(4),
             maxConcurrentConnections: Int = 4,
             bucketSize: Int = 20,
@@ -96,7 +96,7 @@ extension KadDHT {
             self.supportLocalNetwork = supportLocalNetwork
         }
 
-        static var `default`: NodeOptions {
+        public static var `default`: NodeOptions {
             .init()
         }
     }


### PR DESCRIPTION
## Summary

The `NodeOptions` init and stored properties were `internal`, so external
consumers had no way to configure non-default options like
`supportLocalNetwork: true` (needed for loopback testing) without either
using the limited `kadDHT(...)` overload or `@testable import`.

This PR makes the init and stored properties `public` so callers can
construct `NodeOptions` directly.

## Changes

`Sources/LibP2PKadDHT/Networking/Networking.swift`:
- `init(...)` → `public init(...)`
- Stored properties (`connectionTimeout`, `supportLocalNetwork`,
  `bootstrapPeers`, `maxConcurrentConnections`, `bucketSize`,
  `maxPeers`) → `public`

No behavioural changes; pure visibility widening.

## Test Plan

- [ ] CI passes
- [ ] No new tests needed — visibility-only change