### PR TITLE
Fix: storeNew writes locally first, returns true on local success

### DIFF
--- a/Sources/LibP2PKadDHT/Node.swift
+++ b/Sources/LibP2PKadDHT/Node.swift
@@ -853,10 +853,38 @@ public enum KadDHT {
         }
 
         public func storeNew(_ key: [UInt8], value: DHTRecord) -> EventLoopFuture<Bool> {
-            /// Perform key lookup and request the returned closest k peers to store the value
+            /// Perform key lookup and request the returned closest k peers to store the value.
+            ///
+            /// Local-first: store on our own kv before fanning the
+            /// value out to closest peers. Mirrors ``provide(cid:announce:)``,
+            /// which writes its provider record to the local
+            /// ``providerStore`` before announcing. Two consequences:
+            ///
+            /// 1. The publisher's own ``getUsingLookupList`` calls
+            ///    for this key succeed immediately, without a round
+            ///    trip.
+            /// 2. Remote peers performing iterative GET_VALUE on
+            ///    this key can resolve it against the publisher
+            ///    once the publisher is in their routing table —
+            ///    even if the publisher's own routing table was
+            ///    empty at storeNew time (e.g. bootstrap addition
+            ///    hadn't completed yet).
+            ///
+            /// `storeNew` therefore returns `true` whenever the
+            /// local write succeeds, even if no closest-peer
+            /// putValue accepts. Best-effort announce semantics —
+            /// the heartbeat's ``_shareDHTKVs`` will continue
+            /// pushing the value out to closer peers on its own
+            /// cadence.
             let targetID = KadDHT.Key(key)
             let value = value.toProtobuf()
-            return self._nearest(self.routingTable.bucketSize, peersToKey: targetID).flatMap {
+
+            return self.dht.updateValue(value, forKey: targetID).flatMap {
+                _ -> EventLoopFuture<Bool> in
+                self.logger.notice(
+                    "storeNew: stored locally key=\(KadDHT.keyToHumanReadableString(key))"
+                )
+                return self._nearest(self.routingTable.bucketSize, peersToKey: targetID).flatMap {
                 seeds -> EventLoopFuture<Bool> in
                 let lookup = KeyLookup(
                     host: self,
@@ -913,14 +941,18 @@ public enum KadDHT {
                                     }
                                 }
                         }.flatten(on: self.eventLoop).flatMap { results -> EventLoopFuture<Bool> in
-                            self.logger.warning(
-                                "\(results.filter({ $0 }).count)/\(results.count) peers were able to store the value \(value)"
+                            self.logger.notice(
+                                "storeNew: \(results.filter({ $0 }).count)/\(results.count) peers accepted the value (local copy stored regardless)"
                             )
-                            /// return true if any of the peers we're able to store the value
-                            self.logger.warning("\(self.eventLoop.description)")
-                            return self.eventLoop.makeSucceededFuture(results.contains { $0 == true })
+                            /// Local-first semantics: the value is
+                            /// already stored locally — return true.
+                            /// Remote acceptance is advisory; the
+                            /// heartbeat's ``_shareDHTKVs`` will
+                            /// continue propagating the value.
+                            return self.eventLoop.makeSucceededFuture(true)
                         }
                     }
+                }
                 }
             }
         }

--- a/Tests/LibP2PKadDHTTests/ValueStoreTests.swift
+++ b/Tests/LibP2PKadDHTTests/ValueStoreTests.swift
@@ -1,0 +1,167 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the swift-libp2p open source project
+//
+// Copyright (c) 2022-2025 swift-libp2p project authors
+// Licensed under MIT
+//
+// See LICENSE for license information
+// See CONTRIBUTORS for the list of swift-libp2p project authors
+//
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+import CID
+import LibP2P
+import LibP2PNoise
+import LibP2PYAMUX
+import Multihash
+import Testing
+
+@testable import LibP2PKadDHT
+
+/// Regression coverage for the value-store path
+/// (`storeNew` + `getUsingLookupList`).
+///
+/// Before this fix, `storeNew` returned `false` whenever the
+/// publisher's routing table was empty at call time — for
+/// example, immediately after `Application.start()` while the
+/// asynchronous bootstrap-peer addition was still in flight on
+/// the event loop. This broke any caller that wanted to publish
+/// a value soon after node startup.
+///
+/// The fix shifts `storeNew` to local-first semantics — the
+/// value lands in the publisher's own kv store synchronously,
+/// remote acceptance is best-effort, and the return value
+/// reflects local success. Heartbeat's `_shareDHTKVs` continues
+/// pushing the value out on the standard cadence.
+@Suite("Value Store Tests", .serialized)
+final class ValueStoreTests {
+
+    @Test
+    func testStoreNewWithEmptyRoutingTableReturnsTrue() throws {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
+        defer { try! group.syncShutdownGracefully() }
+
+        let dhtParams = KadDHT.NodeOptions(
+            connectionTimeout: .milliseconds(150),
+            maxConcurrentConnections: 3,
+            bucketSize: 5,
+            maxPeers: 15,
+            maxKeyValueStoreEntries: 10,
+            supportLocalNetwork: true
+        )
+
+        let node = try makeHost(
+            mode: .server,
+            options: dhtParams,
+            bootstrapPeers: [],
+            usingGroup: .shared(group)
+        )
+        try node.start()
+        defer { node.shutdown() }
+
+        let key = try syntheticCID("local-first-empty-rt")
+        let record = TestRecord(
+            key: Data(key),
+            value: Data("hello-local-first".utf8)
+        )
+        let accepted = try node.dht.kadDHT.storeNew(key, value: record).wait()
+        #expect(accepted, "storeNew should accept even with empty routing table")
+
+        // Publisher's own get must succeed without any remote
+        // hop — local-first means the value is sitting in our
+        // own kv store.
+        let fetched = try node.dht.kadDHT.getUsingLookupList(key).wait()
+        #expect(fetched != nil, "publisher's own getUsingLookupList should hit the local kv")
+        #expect(fetched?.value == Data("hello-local-first".utf8))
+    }
+
+    @Test(.internalIntegrationTestsEnabled)
+    func testStoreNewCrossNodeRoundTrip() throws {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
+        defer { try! group.syncShutdownGracefully() }
+
+        let dhtParams = KadDHT.NodeOptions(
+            connectionTimeout: .milliseconds(500),
+            maxConcurrentConnections: 3,
+            bucketSize: 5,
+            maxPeers: 15,
+            maxKeyValueStoreEntries: 10,
+            supportLocalNetwork: true
+        )
+
+        let publisher = try makeHost(
+            mode: .server,
+            options: dhtParams,
+            bootstrapPeers: [],
+            usingGroup: .shared(group)
+        )
+        try publisher.start()
+
+        let consumer = try makeHost(
+            mode: .server,
+            options: dhtParams,
+            bootstrapPeers: [publisher.peerInfo],
+            usingGroup: .shared(group)
+        )
+        try consumer.start()
+        defer {
+            publisher.shutdown()
+            consumer.shutdown()
+        }
+
+        let key = try syntheticCID("local-first-cross-node")
+        let record = TestRecord(
+            key: Data(key),
+            value: Data("hello-cross-node".utf8)
+        )
+        let stored = try publisher.dht.kadDHT.storeNew(key, value: record).wait()
+        #expect(stored, "storeNew should accept (local-first semantics)")
+
+        // Give a moment for the consumer's iterative lookup to
+        // discover the publisher.
+        Thread.sleep(forTimeInterval: 0.5)
+
+        let fetched = try consumer.dht.kadDHT.getUsingLookupList(key).wait()
+        #expect(fetched != nil, "consumer should fetch publisher's value via iterative lookup")
+        #expect(fetched?.value == Data("hello-cross-node".utf8))
+    }
+
+    // MARK: - Helpers
+
+    private func syntheticCID(_ tag: String) throws -> [UInt8] {
+        try CID(
+            version: .v1,
+            codec: .raw,
+            multihash: try Multihash(raw: tag.bytes, hashedWith: .sha2_256)
+        ).rawBuffer
+    }
+
+    private var nextPort: Int = Int.random(in: 13000..<14000)
+
+    private func makeHost(
+        mode: KadDHT.Mode = .client,
+        options: KadDHT.NodeOptions = .default,
+        bootstrapPeers: [PeerInfo] = [],
+        usingGroup: Application.EventLoopGroupProvider = .singleton
+    ) throws -> Application {
+        let lib = try Application(.testing, peerID: PeerID(.Ed25519), eventLoopGroupProvider: usingGroup)
+        lib.logger.logLevel = .warning
+        lib.security.use(.noise)
+        lib.muxers.use(.yamux)
+        lib.dht.use(.kadDHT(mode: mode, options: options, bootstrapPeers: bootstrapPeers, autoUpdate: false))
+        lib.servers.use(.tcp(host: "127.0.0.1", port: self.nextPort))
+        self.nextPort += 1
+        return lib
+    }
+}
+
+private struct TestRecord: DHTRecord {
+    let key: Data
+    let value: Data
+    let author: Data = Data()
+    let signature: Data = Data()
+    let timeReceived: String = ""
+}


### PR DESCRIPTION
## Summary

`storeNew(_:value:)` currently sends `putValue` queries to the k-closest
peers found via iterative lookup and returns `results.contains(true)`.
With an empty routing table — the normal state immediately after
`Application.start()` while bootstrap-peer addition is still in flight
on the event loop — the iterative lookup returns no peers, no
`putValue` queries are sent, and the publish reports failure even
though nothing actually went wrong from the publisher's perspective.

This makes the published value unrecoverable even by the publisher's
own `getUsingLookupList`, which is a surprising semantic.

## Fix

Mirror what local-first DHT publishers in other libp2p implementations
do (e.g. go-libp2p, rust-libp2p):

1. `storeNew` writes the value to `self.dht` **synchronously** before
   the iterative lookup.
2. The publisher's own `getUsingLookupList` for the key now resolves
   immediately from local kv.
3. Heartbeat's `_shareDHTKVs` continues pushing the value to closer
   peers on the standard cadence; cross-node `getUsingLookupList`
   resolves once the consumer's iterative lookup reaches the
   publisher.
4. `storeNew` returns `true` on successful local store, regardless of
   remote acceptance — remote results stay advisory and are still
   logged.

## Tests

New `ValueStoreTests` suite pins the local-first behaviour:
- `testStoreNewSucceedsWithEmptyRoutingTable` — single-node case,
  default test run
- `testStoreNewIsRetrievableCrossNode` — two-node case, gated behind
  `PerformInternalIntegrationTests=true` (matching the existing
  `InternalNetworkTests` convention)

The existing internal `testInternalNetwork_Test` round-trip (which
already exercised storeNew + getUsingLookupList through the
explicit-heartbeat dance) is unchanged.

## Test Plan

- [ ] CI passes
- [ ] New `ValueStoreTests` pass
- [ ] Existing 60 tests continue to pass