### PR TITLE
Canonical /ipfs/kad/1.0.0 framing + key-agnostic FIND_NODE (cross-impl interop)

### DIFF
--- a/Sources/LibP2PKadDHT/Lookup/Lookup.swift
+++ b/Sources/LibP2PKadDHT/Lookup/Lookup.swift
@@ -145,7 +145,7 @@ final class Lookup: @unchecked Sendable {
             self.logger.info("Querying \(next.peer.b58String) for id: \(self.target.b58String)")
             self.requestsInProgress += 1
             return on.flatSubmit {
-                self.host._sendQuery(.findNode(id: self.target), to: next, on: on).flatMapAlways { result in
+                self.host._sendQuery(.findNode(key: self.target.id), to: next, on: on).flatMapAlways { result in
                     switch result {
                     case .failure(let error):
                         return self.eventLoop.flatSubmit {
@@ -324,7 +324,7 @@ final class KeyLookup: @unchecked Sendable {
                     self.list.remove(next.peer)
                     return self._recursivelyQueryForTarget(on: on, decrementingQueries: true)
                 }
-                return self.host._sendQuery(.findNode(id: p), to: next, on: on).flatMapAlways { result in
+                return self.host._sendQuery(.findNode(key: p.id), to: next, on: on).flatMapAlways { result in
                     switch result {
                     case .failure(let error):
                         return self.eventLoop.flatSubmit {

--- a/Sources/LibP2PKadDHT/Networking/Network+Query.swift
+++ b/Sources/LibP2PKadDHT/Networking/Network+Query.swift
@@ -17,8 +17,10 @@ import LibP2P
 extension KadDHT {
 
     enum Query: CustomStringConvertible {
-        /// In the request key must be set to the binary PeerId of the node to be found
-        case findNode(id: PeerID)
+        /// In the request key is an arbitrary Kademlia key — canonical
+        /// FIND_NODE returns the closest peers to *any* key, not only to a
+        /// PeerID (e.g. rust-libp2p's bootstrap probes random keys).
+        case findNode(key: [UInt8])
         /// In the request key is an unstructured array of bytes.
         case getValue(key: [UInt8])
         /// In the request record is set to the record to be stored and key on Message is set to equal key of the Record.
@@ -40,10 +42,11 @@ extension KadDHT {
                 req.type = .ping
                 req.key = Data(DispatchTime.now().uptimeNanoseconds.toBytes)
 
-            case let .findNode(pid):
+            case let .findNode(key):
                 req.type = .findNode
-                ///  In the request, key must be set to the binary PeerId of the node to be found
-                req.key = Data(pid.id)
+                /// In the request, key is the Kademlia key whose closest
+                /// peers we want (often, but not necessarily, a PeerId).
+                req.key = Data(key)
 
             case let .getValue(key):
                 req.type = .getValue
@@ -77,24 +80,26 @@ extension KadDHT {
         }
 
         /// This is someone sending our node a query, the remote peer is the initiator, we're just reacting...
+        ///
+        /// `bytes` is one complete protobuf message whose uvarint length
+        /// prefix has already been stripped by the route's
+        /// `VarintFrameDecoder` (see `registerDHTRoute`). We deliberately do
+        /// NOT re-read a length prefix here: the old
+        /// `prefix.value == bytes.count - bytesRead` assertion assumed the
+        /// whole frame arrived in a single read, which breaks against peers
+        /// that segment their writes differently (e.g. rust-libp2p).
         static func decode(_ bytes: [UInt8]) throws -> Query {
-            let prefix = uVarInt(bytes)
-            guard prefix.value > 0, prefix.value == (bytes.count - prefix.bytesRead) else {
-                throw Errors.DecodingErrorInvalidLength
-            }
-            let payload: [UInt8] = [UInt8](bytes.dropFirst(prefix.bytesRead))
-
-            guard let dht = try? DHT.Message(serializedBytes: payload) else { throw Errors.DecodingErrorInvalidType }
+            guard let dht = try? DHT.Message(serializedBytes: bytes) else { throw Errors.DecodingErrorInvalidType }
 
             switch dht.type {
             case .findNode:
                 /// .findNode
-                /// In the request, key must be set to the binary PeerId of the node to be found
+                /// In the request, key is an arbitrary Kademlia key. We do
+                /// NOT require it to be a multihash-shaped PeerId: canonical
+                /// FIND_NODE finds the closest peers to any key, and peers
+                /// like rust-libp2p send raw 32-byte keys during bootstrap.
                 guard dht.hasKey, !dht.key.isEmpty else { throw Errors.DecodingErrorInvalidType }
-                guard let cid = try? PeerID(fromBytesID: [UInt8](dht.key)) else {
-                    throw Errors.DecodingErrorInvalidType
-                }
-                return Query.findNode(id: cid)
+                return Query.findNode(key: [UInt8](dht.key))
 
             case .getValue:
                 /// .findValue
@@ -133,8 +138,8 @@ extension KadDHT {
 
         var description: String {
             switch self {
-            case .findNode(let peerID):
-                return "Query::FindNode(peerID: \(peerID.b58String))"
+            case .findNode(let key):
+                return "Query::FindNode(key: \(KadDHT.keyToHumanReadableString(key)))"
             case .getValue(let key):
                 return "Query::GetValue(key: \(KadDHT.keyToHumanReadableString(key)))"
             case .putValue(let key, let record):

--- a/Sources/LibP2PKadDHT/Node.swift
+++ b/Sources/LibP2PKadDHT/Node.swift
@@ -506,20 +506,19 @@ public enum KadDHT {
             case .ping:
                 return self.eventLoop.makeSucceededFuture(Response.ping)
 
-            case .findNode(let pid):
-                /// If it's us
-                if pid == self.peerID {
-                    return self._nearest(self.routingTable.bucketSize, peersToKey: KadDHT.Key(self.peerID)).flatMap {
-                        addresses -> EventLoopFuture<Response> in
-                        /// .nodeSearch(peers: Array<Multiaddr>(([self.address] + addresses).prefix(self.routingTable.bucketSize))
-                        self.eventLoop.makeSucceededFuture(
-                            Response.findNode(closerPeers: addresses.compactMap { try? DHT.Message.Peer($0) })
-                        )
-                    }
-                } else {
-                    /// Otherwise return the closest other peer we know of...
-                    //return self.nearestPeerTo(multiaddr)
-                    return self.nearest(self.routingTable.bucketSize, toPeer: pid)
+            case .findNode(let key):
+                /// Return the K closest peers we know of to `key` in XOR
+                /// space. `key` is an arbitrary Kademlia key (canonical
+                /// FIND_NODE), so we hash the raw bytes into key space via
+                /// `KadDHT.Key(_:)` rather than requiring a PeerID. When the
+                /// key is a PeerId's bytes this is identical to the old
+                /// `KadDHT.Key(peerID)` path, so swift↔swift lookups are
+                /// unchanged.
+                return self._nearest(self.routingTable.bucketSize, peersToKey: KadDHT.Key(key)).flatMap {
+                    addresses -> EventLoopFuture<Response> in
+                    self.eventLoop.makeSucceededFuture(
+                        Response.findNode(closerPeers: addresses.compactMap { try? DHT.Message.Peer($0) })
+                    )
                 }
 
             case .putValue(let key, let value):

--- a/Sources/LibP2PKadDHT/Routes/routes.swift
+++ b/Sources/LibP2PKadDHT/Routes/routes.swift
@@ -18,7 +18,23 @@ import LibP2P
 func registerDHTRoute(_ app: Application) throws {
     app.group("ipfs", "kad") { kad in
 
-        kad.on("1.0.0", handlers: []) { req -> EventLoopFuture<Response<ByteBuffer>> in
+        // Install a uvarint length-prefix frame decoder on the inbound
+        // side of the `/ipfs/kad/1.0.0` stream. Canonical libp2p frames
+        // every kad message as `uvarint(len) + protobuf`; `VarintFrameDecoder`
+        // buffers across partial reads and emits exactly one complete,
+        // length-prefix-stripped frame per message as `req.payload`.
+        //
+        // Without it the route fired per raw read and `Query.decode` assumed
+        // each read was exactly one whole frame — which only held when the
+        // peer flushed one message per yamux frame (swift↔swift). Peers that
+        // chunk their writes differently (e.g. rust-libp2p) tripped the
+        // length assertion, so we reset the stream and they saw an
+        // UnexpectedEof.
+        //
+        // Only the inbound decoder is installed; the outbound response keeps
+        // its own manual length prefix (`Response.encode`), so it is framed
+        // exactly once.
+        kad.on("1.0.0", handlers: [.varIntFrameDecoder]) { req -> EventLoopFuture<Response<ByteBuffer>> in
 
             req.application.dht.kadDHT.processRequest(req)
 

--- a/Tests/LibP2PKadDHTTests/KadFramingTests.swift
+++ b/Tests/LibP2PKadDHTTests/KadFramingTests.swift
@@ -1,0 +1,129 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the swift-libp2p open source project
+//
+// Copyright (c) 2022-2025 swift-libp2p project authors
+// Licensed under MIT
+//
+// See LICENSE for license information
+// See CONTRIBUTORS for the list of swift-libp2p project authors
+//
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+import LibP2P
+import NIOCore
+import NIOEmbedded
+import Testing
+
+@testable import LibP2PKadDHT
+
+/// Proves the `/ipfs/kad/1.0.0` receive path reassembles messages
+/// correctly regardless of how the peer chunks its writes.
+///
+/// Canonical libp2p frames every kad message as `uvarint(len) + protobuf`.
+/// The route installs `VarintFrameDecoder` and `Query.decode` parses the
+/// already-stripped frame. Previously the route had no frame decoder and
+/// `Query.decode` asserted the whole frame arrived in a single read — which
+/// only held when the peer flushed one message per yamux frame (swift↔swift)
+/// and broke against peers that segment differently (e.g. rust-libp2p).
+///
+/// These tests feed the decoder adversarially-split input — every byte
+/// boundary, byte-by-byte dribble, and multiple messages in one buffer — and
+/// assert it always emits exactly the original frames, each of which
+/// `Query.decode` round-trips.
+@Suite("KadDHT wire framing")
+struct KadFramingTests {
+
+    /// The on-the-wire bytes a sender produces: `uvarint(len) + protobuf`.
+    private func wireBytes(for query: KadDHT.Query) throws -> [UInt8] {
+        try query.encode()
+    }
+
+    /// Runs `bytes`, delivered as `chunks`, through a `VarintFrameDecoder`
+    /// (the exact handler the kad route installs) and returns the emitted,
+    /// length-prefix-stripped frames.
+    private func framesFrom(chunks: [[UInt8]]) throws -> [[UInt8]] {
+        let channel = EmbeddedChannel()
+        try channel.pipeline.addHandler(ByteToMessageHandler(VarintFrameDecoder())).wait()
+        for chunk in chunks where !chunk.isEmpty {
+            var buf = channel.allocator.buffer(capacity: chunk.count)
+            buf.writeBytes(chunk)
+            _ = try channel.writeInbound(buf)
+        }
+        var frames: [[UInt8]] = []
+        while let frame = try channel.readInbound(as: ByteBuffer.self) {
+            frames.append(Array(frame.readableBytesView))
+        }
+        _ = try channel.finish()
+        return frames
+    }
+
+    /// A key large enough that its length prefix is a *multi-byte* uvarint
+    /// (>= 128), so splitting inside the prefix also exercises the varint
+    /// continuation path — not just the prefix/body boundary.
+    private var largeKey: [UInt8] { Array(repeating: UInt8(ascii: "k"), count: 300) }
+
+    @Test("a single frame split at every byte boundary yields exactly one decodable Query")
+    func splitAtEveryBoundary() throws {
+        let key = largeKey
+        let wire = try wireBytes(for: .getValue(key: key))
+        #expect(wire.count > 129, "key should force a multi-byte length prefix")
+
+        for split in 0...wire.count {
+            let frames = try framesFrom(chunks: [Array(wire[0..<split]), Array(wire[split...])])
+            #expect(frames.count == 1, "split at offset \(split) should yield exactly one frame")
+            guard case .getValue(let decodedKey) = try KadDHT.Query.decode(frames[0]) else {
+                Issue.record("split \(split): expected a getValue query")
+                continue
+            }
+            #expect(decodedKey == key, "split \(split): key survived reassembly")
+        }
+    }
+
+    @Test("byte-by-byte dribble reassembles into one frame")
+    func byteByByteDribble() throws {
+        let key = largeKey
+        let wire = try wireBytes(for: .getValue(key: key))
+        let frames = try framesFrom(chunks: wire.map { [$0] })
+        #expect(frames.count == 1)
+        guard case .getValue(let decodedKey) = try KadDHT.Query.decode(frames[0]) else {
+            Issue.record("expected a getValue query")
+            return
+        }
+        #expect(decodedKey == key)
+    }
+
+    @Test("two concatenated messages in one read yield two frames")
+    func twoMessagesInOneBuffer() throws {
+        let k1 = Array("first-key".utf8)
+        let k2 = largeKey
+        let wire = try wireBytes(for: .getValue(key: k1)) + wireBytes(for: .getValue(key: k2))
+        let frames = try framesFrom(chunks: [wire])
+        #expect(frames.count == 2)
+        guard case .getValue(let a) = try KadDHT.Query.decode(frames[0]),
+            case .getValue(let b) = try KadDHT.Query.decode(frames[1])
+        else {
+            Issue.record("expected two getValue queries")
+            return
+        }
+        #expect(a == k1)
+        #expect(b == k2)
+    }
+
+    @Test("FIND_NODE accepts an arbitrary (non-PeerID) key")
+    func findNodeAcceptsArbitraryKey() throws {
+        // rust-libp2p bootstraps with raw 32-byte keys that are not
+        // multihash-shaped PeerIds. The decoder must accept them.
+        let randomKey = (0..<32).map { UInt8($0) }
+        let wire = try wireBytes(for: .findNode(key: randomKey))
+        let frames = try framesFrom(chunks: [wire])
+        #expect(frames.count == 1)
+        guard case .findNode(let decodedKey) = try KadDHT.Query.decode(frames[0]) else {
+            Issue.record("expected a findNode query")
+            return
+        }
+        #expect(decodedKey == randomKey)
+    }
+}

--- a/Tests/LibP2PKadDHTTests/MockNetworkTests.swift
+++ b/Tests/LibP2PKadDHTTests/MockNetworkTests.swift
@@ -138,20 +138,25 @@ struct MockNetworkTests {
         }
 
         /// Test Query.findNode and Response.nodeSearch
-        let query = KadDHT.Query.findNode(id: testAddresses.first!.peer)
+        let targetPeer = testAddresses.first!.peer
+        let query = KadDHT.Query.findNode(key: targetPeer.id)
         let encodedQuery = try query.encode()
 
-        /// Send it over the wire...
-        let decodedQuery = try KadDHT.Query.decode(encodedQuery)
+        /// On the wire a query is `uvarint(len) + protobuf`. The route's
+        /// `VarintFrameDecoder` strips the length prefix before `Query.decode`
+        /// sees it, so drop the prefix here to mirror the receive path.
+        let queryFrame = Array(encodedQuery.dropFirst(uVarInt(encodedQuery).bytesRead))
+        let decodedQuery = try KadDHT.Query.decode(queryFrame)
         print("Recovered Query: \(decodedQuery)")
 
-        guard case .findNode(let peer) = decodedQuery else {
+        guard case .findNode(let key) = decodedQuery else {
             Issue.record("Query is not a findNode")
             return
         }
+        #expect(key == targetPeer.id)
 
         let response = try KadDHT.Response.findNode(
-            closerPeers: testAddresses.filter({ $0.peer != peer }).map { try DHT.Message.Peer($0) }
+            closerPeers: testAddresses.filter({ $0.peer.id != key }).map { try DHT.Message.Peer($0) }
         )
         let encodedResponse = try response.encode()
 
@@ -166,7 +171,11 @@ struct MockNetworkTests {
         print(closerPeers)
 
         #expect(closerPeers.count == testAddresses.count - 1)
-        #expect(try closerPeers.contains(where: { try $0.toPeerInfo().peer == peer }) == false)
+        // Broken out of the `#expect` macro: the inline
+        // `try ... contains(where:) == false` form tripped a Swift
+        // type-checker timeout in this toolchain.
+        let containsTargetPeer = try closerPeers.contains(where: { try $0.toPeerInfo().peer.id == key })
+        #expect(containsTargetPeer == false)
     }
 
     @Test func testDHTFauxNetworkQuery_GetValue_NoValue() throws {


### PR DESCRIPTION
Makes the Kademlia message layer interoperate with other libp2p implementations (validated end-to-end against rust-libp2p 0.55), while preserving swift↔swift behavior. Two divergences from canonical `/ipfs/kad/1.0.0`:

## 1. Framing

The `/ipfs/kad/1.0.0` route installed no frame decoder, and `Query.decode` asserted `prefix.value == bytes.count - bytesRead` — i.e. that each read delivered exactly one whole `uvarint(len) + protobuf` frame. That only holds when the peer flushes one message per yamux frame (swift↔swift); peers that segment their writes differently (e.g. rust-libp2p's `quick_protobuf_codec`) trip the assertion **nondeterministically**, so the stream is reset and they observe an `UnexpectedEof`.

The route now installs `.varIntFrameDecoder` (buffers across partial reads, emits exactly one length-prefix-stripped frame), and `Query.decode` parses that bare protobuf. The outbound response keeps its single manual length prefix, so it's framed once.

## 2. FIND_NODE keys

`Query.decode` required the key to be a multihash-shaped PeerId (`PeerID(fromBytesID:)`), but canonical FIND_NODE returns the closest peers to an **arbitrary** key — and rust-libp2p bootstraps with raw 32-byte keys, which were rejected (stream reset). The `findNode` case now carries `[UInt8]` and the handler hashes it into key space via `KadDHT.Key(_:)`. For a PeerId's bytes this is identical to the previous `KadDHT.Key(peerID)` path, so existing lookups are unchanged.

## Tests

`KadFramingTests` feeds the decoder adversarially-split input — every byte boundary, byte-by-byte dribble, two messages per buffer — and asserts it always reconstructs the original frames; also covers the arbitrary-key FIND_NODE case.

## Validation

- A rust-libp2p 0.55 node's `GET_VALUE` and bootstrap FIND_NODE are now decoded by the swift node (0 decode failures, was failing nondeterministically); rust reads back a stored record.
- swift↔swift unchanged.
- Builds clean against current `main`; a downstream integration suite (513 tests) over TCP+Noise+Yamux+Kademlia passes.

Companion to the half-closure fix in swift-libp2p-yamux#3 (the two together complete the cross-impl request/response round-trip).