### PR TITLE
Keys are Multihashes not CIDs

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -30,11 +30,11 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(url: "https://github.com/swift-libp2p/swift-libp2p.git", .upToNextMinor(from: "0.3.0")),
+        .package(url: "https://github.com/swift-libp2p/swift-libp2p.git", .upToNextMinor(from: "0.3.12")),
 
         // Testing dependencies
-        .package(url: "https://github.com/swift-libp2p/swift-libp2p-noise.git", .upToNextMinor(from: "0.2.0")),
-        .package(url: "https://github.com/swift-libp2p/swift-libp2p-yamux.git", .upToNextMinor(from: "0.2.0")),
+        .package(url: "https://github.com/swift-libp2p/swift-libp2p-noise.git", .upToNextMinor(from: "0.3.0")),
+        .package(url: "https://github.com/swift-libp2p/swift-libp2p-yamux.git", .upToNextMinor(from: "0.3.2")),
         .package(url: "https://github.com/swift-libp2p/swift-libp2p-crypto.git", .upToNextMinor(from: "0.2.0")),
     ],
     targets: [

--- a/Sources/LibP2PKadDHT/Lookup/Lookup.swift
+++ b/Sources/LibP2PKadDHT/Lookup/Lookup.swift
@@ -145,7 +145,7 @@ final class Lookup: @unchecked Sendable {
             self.logger.info("Querying \(next.peer.b58String) for id: \(self.target.b58String)")
             self.requestsInProgress += 1
             return on.flatSubmit {
-                self.host._sendQuery(.findNode(id: self.target), to: next, on: on).flatMapAlways { result in
+                self.host._sendQuery(.findNode(key: self.target.id), to: next, on: on).flatMapAlways { result in
                     switch result {
                     case .failure(let error):
                         return self.eventLoop.flatSubmit {
@@ -317,14 +317,14 @@ final class KeyLookup: @unchecked Sendable {
             )
             self.queriesInProgress += 1
             return on.flatSubmit {
-                guard let p = try? PeerID(fromBytesID: self.target.original) else {
-                    self.logger.warning(
-                        "Query to peer \(next.peer) failed due to having an invalid PeerID, removing them from our list"
-                    )
-                    self.list.remove(next.peer)
-                    return self._recursivelyQueryForTarget(on: on, decrementingQueries: true)
-                }
-                return self.host._sendQuery(.findNode(id: p), to: next, on: on).flatMapAlways { result in
+                /// We send the raw target bytes as the FIND_NODE key.
+                ///
+                /// - Note: This used to require `PeerID(fromBytesID: self.target.original)` first. For a
+                ///   `KeyLookup` the target is a *record* key (e.g. `/pk/<multihash>`), which never parses
+                ///   as a PeerID, so that guard dropped every seed peer and every key lookup returned an
+                ///   empty list — meaning `storeNew` could never find anyone to store to.
+                self.host._sendQuery(.findNode(key: self.target.original), to: next, on: on).flatMapAlways {
+                    result in
                     switch result {
                     case .failure(let error):
                         return self.eventLoop.flatSubmit {
@@ -454,7 +454,7 @@ final class KeyLookup: @unchecked Sendable {
             )
             self.queriesInProgress += 1
             return on.flatSubmit {
-                self.host._sendQuery(.getProviders(cid: self.target.original), to: next, on: on).flatMapAlways {
+                self.host._sendQuery(.getProviders(key: self.target.original), to: next, on: on).flatMapAlways {
                     result in
                     switch result {
                     case .failure(let error):

--- a/Sources/LibP2PKadDHT/Networking/Network+Query.swift
+++ b/Sources/LibP2PKadDHT/Networking/Network+Query.swift
@@ -16,6 +16,10 @@ import LibP2P
 
 extension KadDHT {
 
+    /// The maximum provider key length we'll accept
+    /// - Note: We match go-libp2p-kad-dht's bound in `handleGetProviders` and `handleAddProvider`.
+    static let maxProviderKeyLength: Int = 80
+
     enum Query: CustomStringConvertible {
         /// In the request key must be set to the binary PeerId of the node to be found
         case findNode(id: PeerID)

--- a/Sources/LibP2PKadDHT/Networking/Network+Query.swift
+++ b/Sources/LibP2PKadDHT/Networking/Network+Query.swift
@@ -21,16 +21,29 @@ extension KadDHT {
     static let maxProviderKeyLength: Int = 80
 
     enum Query: CustomStringConvertible {
-        /// In the request key must be set to the binary PeerId of the node to be found
-        case findNode(id: PeerID)
-        /// In the request key is an unstructured array of bytes.
+        /// In the request `key` is the raw target of the lookup.
+        ///
+        /// - Note: This is usually the binary PeerId of the node being looked for, but Kademlia treats it
+        ///   as opaque bytes: `PUT_VALUE`/`GET_VALUE` lookups walk towards a *record* key (e.g.
+        ///   `/pk/<multihash>`), which is not a valid PeerID.
+        case findNode(key: [UInt8])
+        
+        /// In the request, `key` is an unstructured array of bytes.
         case getValue(key: [UInt8])
-        /// In the request record is set to the record to be stored and key on Message is set to equal key of the Record.
+        
+        /// In the request, `record` is set to the record to be stored.
+        /// In the response, `key` is set to equal the key of the Record.
         case putValue(key: [UInt8], record: DHT.Record)
-        /// In the request key is set to a CID.
-        case getProviders(cid: [UInt8])
-        /// In the request key is set to a CID.
-        case addProvider(cid: [UInt8])
+        
+        /// In the request, `key` is the multihash of the content being looked for.
+        ///
+        /// - Note: Provider keys are multihashes, not CIDs.
+        case getProviders(key: [UInt8])
+        
+        /// In the request, `key` is the multihash of the content being provided, and `providerPeers` carries
+        /// the provider's own `PeerInfo` (the entries whose ID matches the sender are the ones recorded).
+        case addProvider(key: [UInt8], providerPeers: [DHT.Message.Peer])
+        
         /// Deprecated message type replaced by the dedicated ping protocol. Implementations may still handle incoming PING requests for backwards compatibility. Implementations must not actively send PING requests.
         case ping  // Deprecated
 
@@ -44,10 +57,11 @@ extension KadDHT {
                 req.type = .ping
                 req.key = Data(DispatchTime.now().uptimeNanoseconds.toBytes)
 
-            case let .findNode(pid):
+            case let .findNode(key):
                 req.type = .findNode
-                ///  In the request, key must be set to the binary PeerId of the node to be found
-                req.key = Data(pid.id)
+                /// In the request, key is the raw lookup target (a binary PeerId, or a record key)
+                guard !key.isEmpty else { throw Errors.encodingError }
+                req.key = Data(key)
 
             case let .getValue(key):
                 req.type = .getValue
@@ -68,11 +82,15 @@ extension KadDHT {
 
             case let .getProviders(key):
                 req.type = .getProviders
+                guard (1...KadDHT.maxProviderKeyLength).contains(key.count) else { throw Errors.encodingError }
                 req.key = Data(key)
 
-            case let .addProvider(key):
+            case let .addProvider(key, providerPeers):
                 req.type = .addProvider
+                guard (1...KadDHT.maxProviderKeyLength).contains(key.count) else { throw Errors.encodingError }
                 req.key = Data(key)
+                /// The provider advertises itself (and its dialable addresses) in `providerPeers`.
+                req.providerPeers = providerPeers
             }
 
             let payload = try [UInt8](req.serializedData())
@@ -93,12 +111,13 @@ extension KadDHT {
             switch dht.type {
             case .findNode:
                 /// .findNode
-                /// In the request, key must be set to the binary PeerId of the node to be found
+                /// In the request, key is the raw lookup target.
+                ///
+                /// - Note: We deliberately do NOT require the key to parse as a `PeerID`. Peers walking
+                ///   towards a record key (e.g. `/pk/<multihash>`) send those bytes here, and rejecting
+                ///   them would break `PUT_VALUE`/`GET_VALUE` interop with go-libp2p.
                 guard dht.hasKey, !dht.key.isEmpty else { throw Errors.DecodingErrorInvalidType }
-                guard let cid = try? PeerID(fromBytesID: [UInt8](dht.key)) else {
-                    throw Errors.DecodingErrorInvalidType
-                }
-                return Query.findNode(id: cid)
+                return Query.findNode(key: [UInt8](dht.key))
 
             case .getValue:
                 /// .findValue
@@ -117,14 +136,18 @@ extension KadDHT {
                 return Query.putValue(key: [UInt8](dht.key), record: rec)
 
             case .getProviders:
-                /// In the request, key is set to a CID.
-                guard dht.hasKey, !dht.key.isEmpty else { throw Errors.DecodingErrorInvalidType }
-                return Query.getProviders(cid: [UInt8](dht.key))
+                /// In the request, key is the multihash of the content being looked for.
+                guard dht.hasKey, (1...KadDHT.maxProviderKeyLength).contains(dht.key.count) else {
+                    throw Errors.DecodingErrorInvalidType
+                }
+                return Query.getProviders(key: [UInt8](dht.key))
 
             case .addProvider:
-                /// In the request, key is set to a CID.
-                guard dht.hasKey, !dht.key.isEmpty else { throw Errors.DecodingErrorInvalidType }
-                return Query.addProvider(cid: [UInt8](dht.key))
+                /// In the request, key is the multihash of the content being provided.
+                guard dht.hasKey, (1...KadDHT.maxProviderKeyLength).contains(dht.key.count) else {
+                    throw Errors.DecodingErrorInvalidType
+                }
+                return Query.addProvider(key: [UInt8](dht.key), providerPeers: dht.providerPeers)
 
             case .ping:
                 /// .ping (deprecated)
@@ -137,16 +160,17 @@ extension KadDHT {
 
         var description: String {
             switch self {
-            case .findNode(let peerID):
-                return "Query::FindNode(peerID: \(peerID.b58String))"
+            case .findNode(let key):
+                return "Query::FindNode(target: \(KadDHT.keyToHumanReadableString(key)))"
             case .getValue(let key):
                 return "Query::GetValue(key: \(KadDHT.keyToHumanReadableString(key)))"
             case .putValue(let key, let record):
                 return "Query::PutValue(key: \(KadDHT.keyToHumanReadableString(key)), record: \(record))"
-            case .getProviders(let cid):
-                return "Query::GetProviders(cid: \(KadDHT.keyToHumanReadableString(cid)))"
-            case .addProvider(let cid):
-                return "Query::AddProviders(cid: \(KadDHT.keyToHumanReadableString(cid)))"
+            case .getProviders(let key):
+                return "Query::GetProviders(key: \(KadDHT.keyToHumanReadableString(key)))"
+            case .addProvider(let key, let providerPeers):
+                return
+                    "Query::AddProviders(key: \(KadDHT.keyToHumanReadableString(key)), providers: \(providerPeers.count))"
             case .ping:
                 return "Query::PING"
             }

--- a/Sources/LibP2PKadDHT/Networking/Network+Response.swift
+++ b/Sources/LibP2PKadDHT/Networking/Network+Response.swift
@@ -142,12 +142,7 @@ extension KadDHT {
 
             case .ping:
                 /// Deprecated...
-                if dht.hasKey {
-                    let tic = UInt64(littleEndian: dht.key.withUnsafeBytes({ $0.pointee }))
-                    print("Ping took \((DispatchTime.now().uptimeNanoseconds - tic) / 1_000_000)ms")
-                }
                 return Response.ping
-            //throw Errors.DecodingErrorInvalidType
 
             default:
                 throw Errors.DecodingErrorInvalidType

--- a/Sources/LibP2PKadDHT/Node.swift
+++ b/Sources/LibP2PKadDHT/Node.swift
@@ -413,13 +413,13 @@ public enum KadDHT {
                                 to: peer,
                                 on: self.eventLoop
                             )
-                                .flatMapAlways { _ -> EventLoopFuture<Void> in
-                                    // Best-effort: per-peer failures are
-                                    // expected; the spec only requires
-                                    // some-of-K to succeed for the
-                                    // record to remain discoverable.
-                                    self.eventLoop.makeSucceededVoidFuture()
-                                }
+                            .flatMapAlways { _ -> EventLoopFuture<Void> in
+                                // Best-effort: per-peer failures are
+                                // expected; the spec only requires
+                                // some-of-K to succeed for the
+                                // record to remain discoverable.
+                                self.eventLoop.makeSucceededVoidFuture()
+                            }
                         }.flatten(on: self.eventLoop).map { _ in () }
                     }
                 }
@@ -1173,74 +1173,74 @@ public enum KadDHT {
                     "storeNew: stored locally key=\(KadDHT.keyToHumanReadableString(key))"
                 )
                 return self._nearest(self.routingTable.bucketSize, peersToKey: targetID).flatMap {
-                seeds -> EventLoopFuture<Bool> in
-                let lookup = KeyLookup(
-                    host: self,
-                    target: targetID,
-                    concurrentRequests: self.maxConcurrentRequest,
-                    seeds: seeds,
-                    groupProvider: self.network!.eventLoopGroupProvider
-                )
-                /// Jump back onto our main event loop to ensure that we're not piggy backing on the lookup's eventloop that's trying to shutdown...
-                return lookup.proceedForPeers().hop(to: self.eventLoop).flatMap {
-                    nearestPeers -> EventLoopFuture<Bool> in
-                    let closestPeers = nearestPeers.compactMap { $0.peer == self.peerID ? nil : $0 }
-                    /// We have the closest peers to this key that the network knows of...
-                    /// Take this opportunity to process / store these new peers
-                    return self.addPeersIfSpaceOrCloser(closestPeers).flatMapAlways { _ -> EventLoopFuture<Bool> in
-                        /// Lets ask each one to store the value and hope at least one returns true
-                        self.logger.warning(
-                            "Asking the closest \(closestPeers.count) peers to store our value \(value)"
-                        )
-                        /// TODO: We need to limit concurrent queries here as well..
-                        //guard let externalAddys = self.network?.externalListeningAddresses, !externalAddys.isEmpty else {
-                        //    return self.eventLoop.makeFailedFuture(Errors.cantPutValueWithoutExternallyDialableAddress)
-                        //}
-                        //let providerInfo = Peer.PeerInfo(id: self.peerID, addresses: externalAddys)
-                        var record = DHT.Record()
-                        record.key = value.key  //Data(targetID.bytes)
-                        record.value = value.value
-                        //record.timeReceived = value.timeReceived
-                        return closestPeers.prefix(4).compactMap { peer in
-                            self._sendQuery(.putValue(key: key, record: record), to: peer, on: self.eventLoop)
-                                .flatMapAlways { res -> EventLoopFuture<Bool> in
-                                    switch res {
-                                    case .success(let response):
-                                        self.logger.info("PutValue Response -> \(response)")
-                                        guard case .putValue(let k, let rec) = response else {
+                    seeds -> EventLoopFuture<Bool> in
+                    let lookup = KeyLookup(
+                        host: self,
+                        target: targetID,
+                        concurrentRequests: self.maxConcurrentRequest,
+                        seeds: seeds,
+                        groupProvider: self.network!.eventLoopGroupProvider
+                    )
+                    /// Jump back onto our main event loop to ensure that we're not piggy backing on the lookup's eventloop that's trying to shutdown...
+                    return lookup.proceedForPeers().hop(to: self.eventLoop).flatMap {
+                        nearestPeers -> EventLoopFuture<Bool> in
+                        let closestPeers = nearestPeers.compactMap { $0.peer == self.peerID ? nil : $0 }
+                        /// We have the closest peers to this key that the network knows of...
+                        /// Take this opportunity to process / store these new peers
+                        return self.addPeersIfSpaceOrCloser(closestPeers).flatMapAlways { _ -> EventLoopFuture<Bool> in
+                            /// Lets ask each one to store the value and hope at least one returns true
+                            self.logger.warning(
+                                "Asking the closest \(closestPeers.count) peers to store our value \(value)"
+                            )
+                            /// TODO: We need to limit concurrent queries here as well..
+                            //guard let externalAddys = self.network?.externalListeningAddresses, !externalAddys.isEmpty else {
+                            //    return self.eventLoop.makeFailedFuture(Errors.cantPutValueWithoutExternallyDialableAddress)
+                            //}
+                            //let providerInfo = Peer.PeerInfo(id: self.peerID, addresses: externalAddys)
+                            var record = DHT.Record()
+                            record.key = value.key  //Data(targetID.bytes)
+                            record.value = value.value
+                            //record.timeReceived = value.timeReceived
+                            return closestPeers.prefix(4).compactMap { peer in
+                                self._sendQuery(.putValue(key: key, record: record), to: peer, on: self.eventLoop)
+                                    .flatMapAlways { res -> EventLoopFuture<Bool> in
+                                        switch res {
+                                        case .success(let response):
+                                            self.logger.info("PutValue Response -> \(response)")
+                                            guard case .putValue(let k, let rec) = response else {
+                                                return self.eventLoop.makeSucceededFuture(false)
+                                            }
+                                            self.logger.info("PutValue Response from...")
+                                            self.logger.info("Peer: \(peer.peer.b58String)")
+                                            self.logger.info("Addresses: \(peer.addresses)")
+                                            self.logger.info("Query Key: \(key)")
+                                            self.logger.info("Response Key: \(k)")
+                                            self.logger.info("Query Rec: \(value)")
+                                            if let rec = rec {
+                                                self.logger.info("Response Rec: \(rec)")
+                                            } else {
+                                                self.logger.info("Response Rec: NIL")
+                                            }
+
+                                            return self.eventLoop.makeSucceededFuture(rec != nil && k == key)
+                                        case .failure(let error):
+                                            self.logger.info("PutValue Error -> \(error)")
                                             return self.eventLoop.makeSucceededFuture(false)
                                         }
-                                        self.logger.info("PutValue Response from...")
-                                        self.logger.info("Peer: \(peer.peer.b58String)")
-                                        self.logger.info("Addresses: \(peer.addresses)")
-                                        self.logger.info("Query Key: \(key)")
-                                        self.logger.info("Response Key: \(k)")
-                                        self.logger.info("Query Rec: \(value)")
-                                        if let rec = rec {
-                                            self.logger.info("Response Rec: \(rec)")
-                                        } else {
-                                            self.logger.info("Response Rec: NIL")
-                                        }
-
-                                        return self.eventLoop.makeSucceededFuture(rec != nil && k == key)
-                                    case .failure(let error):
-                                        self.logger.info("PutValue Error -> \(error)")
-                                        return self.eventLoop.makeSucceededFuture(false)
                                     }
-                                }
-                        }.flatten(on: self.eventLoop).flatMap { results -> EventLoopFuture<Bool> in
-                            self.logger.notice(
-                                "storeNew: \(results.filter({ $0 }).count)/\(results.count) peers accepted the value (local copy stored regardless)"
-                            )
-                            /// Local-first semantics: the value is
-                            /// already stored locally — return true.
-                            /// Remote acceptance is advisory; the
-                            /// heartbeat's ``_shareDHTKVs`` will
-                            /// continue propagating the value.
-                            return self.eventLoop.makeSucceededFuture(true)
+                            }.flatten(on: self.eventLoop).flatMap { results -> EventLoopFuture<Bool> in
+                                self.logger.notice(
+                                    "storeNew: \(results.filter({ $0 }).count)/\(results.count) peers accepted the value (local copy stored regardless)"
+                                )
+                                /// Local-first semantics: the value is
+                                /// already stored locally — return true.
+                                /// Remote acceptance is advisory; the
+                                /// heartbeat's ``_shareDHTKVs`` will
+                                /// continue propagating the value.
+                                return self.eventLoop.makeSucceededFuture(true)
+                            }
                         }
                     }
-                }
                 }
             }
         }

--- a/Sources/LibP2PKadDHT/Node.swift
+++ b/Sources/LibP2PKadDHT/Node.swift
@@ -508,20 +508,25 @@ public enum KadDHT {
             case .ping:
                 return self.eventLoop.makeSucceededFuture(Response.ping)
 
-            case .findNode(let pid):
-                /// If it's us
-                if pid == self.peerID {
-                    return self._nearest(self.routingTable.bucketSize, peersToKey: KadDHT.Key(self.peerID)).flatMap {
-                        addresses -> EventLoopFuture<Response> in
-                        /// .nodeSearch(peers: Array<Multiaddr>(([self.address] + addresses).prefix(self.routingTable.bucketSize))
-                        self.eventLoop.makeSucceededFuture(
-                            Response.findNode(closerPeers: addresses.compactMap { try? DHT.Message.Peer($0) })
-                        )
+            case .findNode(let target):
+                /// If they're looking for us, tell them about us.
+                ///
+                /// - Note: go's `handleFindPeer` answers `[self]` in this case. Returning our *neighbours*
+                ///   instead (which is what we used to do, since `_nearest` filters us out) means a peer
+                ///   asking us directly for our own address never learns it.
+                if target == self.peerID.id {
+                    return self.eventLoop.submit {
+                        guard let us = try? DHT.Message.Peer(PeerInfo(peer: self.peerID, addresses: self.ourAddresses()))
+                        else { return Response.findNode(closerPeers: []) }
+                        return Response.findNode(closerPeers: [us])
                     }
                 } else {
-                    /// Otherwise return the closest other peer we know of...
-                    //return self.nearestPeerTo(multiaddr)
-                    return self.nearest(self.routingTable.bucketSize, toPeer: pid)
+                    /// Otherwise return the k closest peers we know of to the target
+                    return self.nearest(
+                        self.routingTable.bucketSize,
+                        toKey: KadDHT.Key(target, keySpace: .xor),
+                        excluding: from.peer
+                    )
                 }
 
             case .putValue(let key, let value):
@@ -569,87 +574,90 @@ public enum KadDHT {
                 /// If we have the value, send it back!
                 let kid = KadDHT.Key(key, keySpace: .xor)
                 request.logger.notice("Query::GetValue::\(KadDHT.keyToHumanReadableString(key))")
-                return self.dht.getValue(forKey: kid).flatMap { value in
-                    if let value = value {
-                        request.logger.notice(
-                            "Query::GetValue::Returning value for key: \(KadDHT.keyToHumanReadableString(key))"
+                /// - Note: We attach the k closest peers whether or not we hold the record. go's
+                ///   `handleGetValue` sets `Record` and `CloserPeers` unconditionally; only sending closer
+                ///   peers on a miss truncates the requester's lookup at the first hop that has a copy.
+                return self.dht.getValue(forKey: kid).and(
+                    self._nearest(self.routingTable.bucketSize, peersToKey: kid, excluding: from.peer)
+                ).map { value, peers in
+                    request.logger.notice(
+                        "Query::GetValue::Returning \(value == nil ? "no value" : "value") and \(peers.count) closer peers for key: \(KadDHT.keyToHumanReadableString(key))"
+                    )
+                    return Response.getValue(
+                        key: key,
+                        record: value,
+                        closerPeers: peers.compactMap { try? DHT.Message.Peer($0) }
+                    )
+                }
+
+            case .getProviders(let key):
+                /// - Note: The key here is a multihash, not a CID, so we don't try to parse it. go's
+                ///   `handleGetProviders` only bounds the length, which `Query.decode` has already done.
+                ///   Rejecting anything that isn't a valid CID broke every non-sha2-256 multihash.
+                let kid = KadDHT.Key(key, keySpace: .xor)
+
+                /// Return the providers we know of *and* the k closest peers, matching go.
+                return self.providerStore.getValue(forKey: kid).and(
+                    self._nearest(self.routingTable.bucketSize, peersToKey: kid, excluding: from.peer)
+                ).map { providers, peers in
+                    let providers = providers ?? []
+                    request.logger.notice(
+                        "Query::GetProviders::Returning \(providers.count) providers and \(peers.count) closer peers for key: \(KadDHT.keyToHumanReadableString(key))"
+                    )
+                    return Response.getProviders(
+                        cid: key,
+                        providerPeers: providers,
+                        closerPeers: peers.compactMap { try? DHT.Message.Peer($0) }
+                    )
+                }
+
+            case .addProvider(let key, let advertised):
+                let kid = KadDHT.Key(key, keySpace: .xor)
+
+                /// Only record the advertised `providerPeers` entries that match the sender's PeerID, per the
+                /// spec ("validate that the received PeerInfo matches the sender's peerID"). Those entries
+                /// are where the provider's dialable addresses come from — we used to discard them entirely
+                /// and store only the address we happened to observe this connection on.
+                let provider: DHT.Message.Peer?
+                if let matching = advertised.first(where: { $0.id == Data(from.peer.id) }),
+                    let matchingInfo = try? matching.toPeerInfo(),
+                    !matchingInfo.addresses.isEmpty
+                {
+                    /// Union the addresses they advertised with the one we observed.
+                    let addresses = matchingInfo.addresses + from.addresses.filter { !matchingInfo.addresses.contains($0) }
+                    provider = try? DHT.Message.Peer(PeerInfo(peer: from.peer, addresses: addresses))
+                } else {
+                    if !advertised.isEmpty {
+                        request.logger.warning(
+                            "Query::AddProvider::No providerPeers entry matched sender \(from.peer), falling back to the observed address"
                         )
-                        return self.eventLoop.makeSucceededFuture(
-                            Response.getValue(key: key, record: value, closerPeers: [])
-                        )
-                    } else {
-                        return self._nearest(self.routingTable.bucketSize, peersToKey: kid).flatMap { peers in
-                            request.logger.notice(
-                                "Query::GetValue::Returning \(peers.count) closer peers for key: \(KadDHT.keyToHumanReadableString(key))"
-                            )
-                            return self.eventLoop.makeSucceededFuture(
-                                Response.getValue(
-                                    key: key,
-                                    record: nil,
-                                    closerPeers: peers.compactMap { try? DHT.Message.Peer($0) }
-                                )
-                            )
-                        }
                     }
+                    provider = try? DHT.Message.Peer(from)
                 }
 
-            case .getProviders(let cid):
-                /// Is this correct?? The same thing a getValue?
-                guard let CID = try? CID(cid) else {
-                    return self.eventLoop.makeSucceededFuture(Response.addProvider(cid: cid, providerPeers: []))
+                guard let provider else {
+                    return self.eventLoop.makeSucceededFuture(Response.addProvider(cid: key, providerPeers: []))
                 }
-                let kid = KadDHT.Key(cid, keySpace: .xor)
 
-                return self.providerStore.getValue(forKey: kid).flatMap { value in
-                    if let value = value, !value.isEmpty {
+                return self.providerStore.getValue(forKey: kid).flatMap { existingProviders in
+                    let existingProviders = existingProviders ?? []
+                    /// - Note: This condition used to be inverted, so a provider we'd never seen was
+                    ///   reported as "already a provider" and dropped, while a provider we already had was
+                    ///   appended a second time. Since the store always started empty, nothing was ever
+                    ///   recorded and GET_PROVIDERS could never return anybody.
+                    guard !existingProviders.contains(provider) else {
                         request.logger.notice(
-                            "Query::GetProviders::Returning \(value.count) Provider Peers for CID: \(CID.multihash.b58String)"
+                            "Query::AddProvider::\(from.peer) already a provider for key: \(KadDHT.keyToHumanReadableString(key))"
                         )
                         return self.eventLoop.makeSucceededFuture(
-                            Response.getProviders(cid: cid, providerPeers: value, closerPeers: [])
+                            Response.addProvider(cid: key, providerPeers: [provider])
                         )
-                    } else {
-                        /// Otherwise return the k closest peers we know of to the key being searched for (excluding us)
-                        return self._nearest(self.routingTable.bucketSize, peersToKey: kid).flatMap { peers in
-                            request.logger.notice(
-                                "Query::GetProviders::Returning \(peers.count) Closer Peers for CID: \(CID.multihash.b58String)"
-                            )
-                            return self.eventLoop.makeSucceededFuture(
-                                Response.getProviders(
-                                    cid: cid,
-                                    providerPeers: [],
-                                    closerPeers: peers.compactMap { try? DHT.Message.Peer($0) }
-                                )
-                            )
-                        }
                     }
-                }
-
-            case .addProvider(let cid):
-                // Ensure the provided CID is valid...
-                guard let CID = try? CID(cid) else {
-                    return self.eventLoop.makeSucceededFuture(Response.addProvider(cid: cid, providerPeers: []))
-                }
-                let kid = KadDHT.Key(cid, keySpace: .xor)
-                guard let provider = try? DHT.Message.Peer(from) else {
-                    return self.eventLoop.makeSucceededFuture(Response.addProvider(cid: cid, providerPeers: []))
-                }
-
-                return self.providerStore.getValue(forKey: kid, default: []).flatMap { existingProviders in
-                    if !existingProviders.contains(provider) {
+                    return self.providerStore.updateValue(existingProviders + [provider], forKey: kid).map { _ in
                         request.logger.notice(
-                            "Query::AddProvider::\(from.peer) already a provider for cid: \(CID.multihash.b58String)"
+                            "Query::AddProvider::Added \(from.peer) as a provider for key: \(KadDHT.keyToHumanReadableString(key))"
                         )
-                        return self.eventLoop.makeSucceededFuture(
-                            Response.addProvider(cid: cid, providerPeers: [provider])
-                        )
-                    } else {
-                        return self.providerStore.updateValue(existingProviders + [provider], forKey: kid).map { _ in
-                            request.logger.notice(
-                                "Query::AddProvider::Added \(from.peer) as a provider for cid: \(CID.multihash.b58String)"
-                            )
-                            return Response.addProvider(cid: cid, providerPeers: [provider])
-                        }
+                        return Response.addProvider(cid: key, providerPeers: [provider])
                     }
                 }
             }
@@ -1311,17 +1319,15 @@ public enum KadDHT {
             }
         }
 
-        /// Returns up to the specified number of closest peers to the provided multiaddress, excluding ourselves
-        private func nearest(_ num: Int, toPeer peer: PeerID) -> EventLoopFuture<Response> {
-            //guard let peer = self.multiaddressToPeerID(ma) else { return self.eventLoop.makeFailedFuture(Errors.unknownPeer) }
-
-            self.routingTable.nearest(num, peersTo: peer).flatMap { peerInfos in
-                peerInfos.filter { $0.id.id != self.peerID.id }.compactMap {
-                    //self.peerstore[$0.id.b58String]
-                    self.peerstore.getPeerInfo(byID: $0.id.b58String)
-                }.flatten(on: self.eventLoop).map { ps in
-                    Response.findNode(closerPeers: ps.compactMap { try? DHT.Message.Peer($0) })
-                }
+        /// Returns a `findNode` response containing up to `num` of the closest peers we know of to `key`,
+        /// excluding ourselves and (optionally) the peer that asked.
+        private func nearest(
+            _ num: Int,
+            toKey key: KadDHT.Key,
+            excluding requester: PeerID? = nil
+        ) -> EventLoopFuture<Response> {
+            self._nearest(num, peersToKey: key, excluding: requester).map { ps in
+                Response.findNode(closerPeers: ps.compactMap { try? DHT.Message.Peer($0) })
             }
         }
 
@@ -1340,12 +1346,35 @@ public enum KadDHT {
             }
         }
 
-        /// Returns up to the specified number of closest peers to the provided multiaddress, excluding ourselves
-        private func _nearest(_ num: Int, peersToKey keyID: KadDHT.Key) -> EventLoopFuture<[PeerInfo]> {
+        /// Returns up to the specified number of closest peers to the provided key, excluding ourselves and
+        /// (optionally) the peer that asked us.
+        ///
+        /// - Parameter requester: When answering a query, pass the requesting peer. go's
+        ///   `betterPeersToQuery` never tells a peer about itself, and echoing the requester back wastes a
+        ///   `closerPeers` slot and makes them re-query themselves.
+        private func _nearest(
+            _ num: Int,
+            peersToKey keyID: KadDHT.Key,
+            excluding requester: PeerID? = nil
+        ) -> EventLoopFuture<[PeerInfo]> {
             self.routingTable.nearest(num, peersToKey: keyID).flatMap { peerInfos in
-                peerInfos.filter { $0.id.id != self.peerID.id }.compactMap {
+                peerInfos.filter { peer in
+                    peer.id != self.peerID && peer.id != requester
+                }.compactMap {
                     self.peerstore.getPeerInfo(byID: $0.id.b58String)
                 }.flatten(on: self.eventLoop)
+            }
+        }
+
+        /// Our own dialable addresses, each guaranteed to carry our PeerID.
+        ///
+        /// Used when answering a FIND_NODE for our own ID.
+        private func ourAddresses() -> [Multiaddr] {
+            let candidates = self.network?.listenAddresses ?? []
+            let addresses = candidates.isEmpty ? [self.address].compactMap { $0 } : candidates
+            return addresses.compactMap { addy in
+                addy.getPeerIDString() != nil
+                    ? addy : try? addy.encapsulate(proto: .p2p, address: self.peerID.b58String)
             }
         }
     }

--- a/Sources/LibP2PKadDHT/Node.swift
+++ b/Sources/LibP2PKadDHT/Node.swift
@@ -286,7 +286,9 @@ public enum KadDHT {
 
         public func findProviders(cid: [UInt8], count: Int) -> EventLoopFuture<[Multiaddr]> {
             guard let cid = try? CID(cid) else { return self.eventLoop.makeFailedFuture(Errors.invalidCID) }
-            return self.getProvidersUsingLookupList(cid.rawBuffer).map { peers in
+            /// Provider records are keyed by *multihash*, not by CID, so that every CID encoding of the same
+            /// content converges on one key. `rawBuffer` would include the v1 version/codec prefix.
+            return self.getProvidersUsingLookupList(cid.multihash.value).map { peers in
                 peers.reduce(
                     into: [],
                     { partialResult, pInfo in

--- a/Sources/LibP2PKadDHT/RoutingTable/Bucket.swift
+++ b/Sources/LibP2PKadDHT/RoutingTable/Bucket.swift
@@ -95,8 +95,6 @@ extension Bucket {
     }
 
     func maxCommonPrefixLength(target: ID) -> Int {
-        self.max { lhs, rhs in
-            lhs.dhtID.bytes.commonPrefixLength(with: target) > rhs.dhtID.bytes.commonPrefixLength(with: target)
-        }!.dhtID.bytes.commonPrefixLength(with: target)
+        self.map { $0.dhtID.bytes.commonPrefixLength(with: target) }.max() ?? 0
     }
 }

--- a/Sources/LibP2PKadDHT/RoutingTable/RoutingTable.swift
+++ b/Sources/LibP2PKadDHT/RoutingTable/RoutingTable.swift
@@ -172,12 +172,16 @@ class RoutingTable: EventLoopService, @unchecked Sendable {
         }
 
         /// If the peer already exists in the Routing Table
-        if var peer = self.buckets[bucketID].getPeer(peer) {
-            /// if we're querying the peer first time after adding it, let's give it a usefulness bump.
-            /// - Note: This will ONLY happen once.
-            if peer.lastUsefulAt == nil && isQueryPeer {
-                peer.lastUsefulAt = lastUsefulAt
+        if self.buckets[bucketID].getPeer(
+            peer,
+            modifier: { existing in
+                /// if we're querying the peer first time after adding it, let's give it a usefulness bump.
+                /// - Note: This will ONLY happen once.
+                if existing.lastUsefulAt == nil && isQueryPeer {
+                    existing.lastUsefulAt = lastUsefulAt
+                }
             }
+        ) {
             return false
         }
 
@@ -373,12 +377,16 @@ class RoutingTable: EventLoopService, @unchecked Sendable {
             }
 
             /// If the peer already exists in the Routing Table
-            if var peer = self.buckets[bucketID].getPeer(peer) {
-                /// if we're querying the peer first time after adding it, let's give it a usefulness bump.
-                /// - Note: This will ONLY happen once.
-                if peer.lastUsefulAt == nil && isQueryPeer {
-                    peer.lastUsefulAt = lastUsefulAt
+            if self.buckets[bucketID].getPeer(
+                peer,
+                modifier: { existing in
+                    /// if we're querying the peer first time after adding it, let's give it a usefulness bump.
+                    /// - Note: This will ONLY happen once.
+                    if existing.lastUsefulAt == nil && isQueryPeer {
+                        existing.lastUsefulAt = lastUsefulAt
+                    }
                 }
+            ) {
                 self.logger.debug("Peer Already Exists. Returning Without Adding")
                 return false
             }

--- a/Sources/LibP2PKadDHT/RoutingTable/RoutingTable.swift
+++ b/Sources/LibP2PKadDHT/RoutingTable/RoutingTable.swift
@@ -862,7 +862,7 @@ class RoutingTable: EventLoopService, @unchecked Sendable {
         /// Sort the peers by their distance to our local key and return the requested number of closest peers
         return [DHTPeerInfo](
             peersToSort.sorted(by: { lhs, rhs in
-                peer.compareDistancesFromSelf(to: lhs.dhtID, and: rhs.dhtID).rawValue >= 0
+                peer.compareDistancesFromSelf(to: lhs.dhtID, and: rhs.dhtID) == .firstKey
             }).prefix(count)
         )
     }

--- a/Sources/LibP2PKadDHT/RoutingTable/RoutingTable.swift
+++ b/Sources/LibP2PKadDHT/RoutingTable/RoutingTable.swift
@@ -126,7 +126,7 @@ class RoutingTable: EventLoopService, @unchecked Sendable {
     func stop() throws {
         guard self._state == .started else { return }
         self._state = .stopped
-        try self.eventLoop.close()
+        /// - Note: We deliberately don't close our `eventLoop` here. It's shared with the `KadDHT.Node`.
     }
 
     func numberOfPeers(withCommonPrefixLength cpl: Int) -> EventLoopFuture<Int> {

--- a/Sources/LibP2PKadDHT/RoutingTable/RoutingTable.swift
+++ b/Sources/LibP2PKadDHT/RoutingTable/RoutingTable.swift
@@ -669,7 +669,7 @@ class RoutingTable: EventLoopService, @unchecked Sendable {
     }
 
     public func markPeerIrreplaceable(_ peer: DHTPeerInfo) -> EventLoopFuture<Bool> {
-        self.eventLoop.submit { self._markPeerReplaceable(peer) }
+        self.eventLoop.submit { self._markPeerIrreplaceable(peer) }
     }
 
     private func _markPeerIrreplaceable(_ peer: DHTPeerInfo) -> Bool {

--- a/Tests/LibP2PKadDHTTests/ConcurrentWorkersTests.swift
+++ b/Tests/LibP2PKadDHTTests/ConcurrentWorkersTests.swift
@@ -19,153 +19,157 @@ import Testing
 
 @testable import LibP2PKadDHT
 
-@Suite("Concurrent Workers Test")
-struct ConcurrentWorkersTests {
+extension LibP2PKadDHTTests {
 
-    /// This test spawns a group of workers that work on a single (thread protected) list of 'work'.
-    /// Each worker checks for work to be done, recursively, then performs the work on their own eventloop and returns when there is no more work to be done.
-    /// - Note: This example allocates all work up front (doesn't add new work to the queue over time).
-    /// - Note: Our LookupLists use a different algorithm than this...
-    @Test func testEventLoopGroupConcurrentWorkers() async throws {
+    @Suite("Concurrent Workers Test")
+    struct ConcurrentWorkersTests {
 
-        let group = MultiThreadedEventLoopGroup(numberOfThreads: 4)
+        /// This test spawns a group of workers that work on a single (thread protected) list of 'work'.
+        /// Each worker checks for work to be done, recursively, then performs the work on their own eventloop and returns when there is no more work to be done.
+        /// - Note: This example allocates all work up front (doesn't add new work to the queue over time).
+        /// - Note: Our LookupLists use a different algorithm than this...
+        @Test func testEventLoopGroupConcurrentWorkers() async throws {
 
-        let workers: Int = 4
+            let group = MultiThreadedEventLoopGroup(numberOfThreads: 4)
 
-        var stuffToDo: [(taskDuration: UInt32, processed: Bool)] = (0..<20).map {
-            i -> (taskDuration: UInt32, processed: Bool) in
-            (UInt32.random(in: 10_000...1_000_000), false)
-        }
+            let workers: Int = 4
 
-        print(stuffToDo)
-
-        let mainLoop = group.next()
-
-        @Sendable func nextTask() -> EventLoopFuture<UInt32?> {
-            mainLoop.submit {
-                guard let next = stuffToDo.firstIndex(where: { $0.processed == false }) else { return nil }
-                print("Dequeing task \(next) for work")
-                stuffToDo[next].processed = true
-                return stuffToDo[next].taskDuration
+            var stuffToDo: [(taskDuration: UInt32, processed: Bool)] = (0..<20).map {
+                i -> (taskDuration: UInt32, processed: Bool) in
+                (UInt32.random(in: 10_000...1_000_000), false)
             }
-        }
 
-        @Sendable func recursivelyWork(worker: Int, on: EventLoop) -> EventLoopFuture<Void> {
-            nextTask().flatMap { task in
-                on.flatSubmit {
-                    guard let task = task else { return on.makeSucceededVoidFuture() }
-                    print("Worker \(worker) performing next task")
-                    self.doSomeWork(duration: task)
-                    return recursivelyWork(worker: worker, on: on)
+            print(stuffToDo)
+
+            let mainLoop = group.next()
+
+            @Sendable func nextTask() -> EventLoopFuture<UInt32?> {
+                mainLoop.submit {
+                    guard let next = stuffToDo.firstIndex(where: { $0.processed == false }) else { return nil }
+                    print("Dequeing task \(next) for work")
+                    stuffToDo[next].processed = true
+                    return stuffToDo[next].taskDuration
                 }
             }
-        }
 
-        let workExpectation = AsyncSemaphore(value: 0)
-
-        (0..<workers).compactMap { worker -> EventLoopFuture<Void> in
-            print("Deploying Worker")
-            return recursivelyWork(worker: worker, on: group.next())
-        }.flatten(on: mainLoop).whenComplete { result in
-            switch result {
-            case .failure(let error):
-                print("Error: \(error)")
-            case .success:
-                print("All done with work")
-                print(stuffToDo)
+            @Sendable func recursivelyWork(worker: Int, on: EventLoop) -> EventLoopFuture<Void> {
+                nextTask().flatMap { task in
+                    on.flatSubmit {
+                        guard let task = task else { return on.makeSucceededVoidFuture() }
+                        print("Worker \(worker) performing next task")
+                        self.doSomeWork(duration: task)
+                        return recursivelyWork(worker: worker, on: on)
+                    }
+                }
             }
-            workExpectation.signal()
+
+            let workExpectation = AsyncSemaphore(value: 0)
+
+            (0..<workers).compactMap { worker -> EventLoopFuture<Void> in
+                print("Deploying Worker")
+                return recursivelyWork(worker: worker, on: group.next())
+            }.flatten(on: mainLoop).whenComplete { result in
+                switch result {
+                case .failure(let error):
+                    print("Error: \(error)")
+                case .success:
+                    print("All done with work")
+                    print(stuffToDo)
+                }
+                workExpectation.signal()
+            }
+
+            await workExpectation.wait()
+
+            print("Shutting down event loop")
+            try await group.shutdownGracefully()
         }
 
-        await workExpectation.wait()
+        @Sendable private func doSomeWork(duration: UInt32) {
+            usleep(duration)
+        }
 
-        print("Shutting down event loop")
-        try await group.shutdownGracefully()
+        //    class WorkerGroup {
+        //        let maxConcurrentWorkers:Int
+        //        let group:MultiThreadedEventLoopGroup
+        //        var tasks:[(Int) -> EventLoopFuture<[Int]>]
+        //    }
+
+        //    struct Worker {
+        //        let eventloop:EventLoop
+        //        var isWorking:Bool = false
+        //
+        //        mutating func markWorking(_ working:Bool) {
+        //            isWorking = working
+        //        }
+        //    }
+        //
+        //    /// This test spawns a group of workers that work on a single (thread protected) list of 'work'.
+        //    /// Each worker checks for work to be done, recursively, then performs the work on their own eventloop and returns when there is no more work to be done.
+        //    func testEventLoopGroupConcurrentWorkersSmart() throws {
+        //
+        //        let group = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
+        //
+        //        let maxWorkers:Int = 2
+        //        var workers:[Worker] = []
+        //
+        //        var stuffToDo:[(taskDuration:UInt32, processed:Bool)] = (0..<10).map { i -> (taskDuration:UInt32, processed:Bool) in
+        //            return (UInt32.random(in: 2...5), false)
+        //        }
+        //
+        //        let mainLoop = group.next()
+        //        let timeoutPerTask:TimeAmount = .seconds(6)
+        //        let timeoutPerGroup:TimeAmount = .minutes(1)
+        //
+        //        /// Create our workers
+        //        workers = (0..<maxWorkers).map { _ in Worker(eventloop: group.next()) }
+        //
+        //        func nextTask() -> EventLoopFuture<UInt32?> {
+        //            mainLoop.submit {
+        //                guard let next = stuffToDo.firstIndex(where: { $0.processed == false }) else { return nil }
+        //                print("Dequeing task \(next) for work")
+        //                stuffToDo[next].processed = true
+        //                return stuffToDo[next].taskDuration
+        //            }
+        //        }
+        //
+        //        func nextWorker() -> Worker? {
+        //            mainLoop.submit {
+        //                workers.first(where: { $0.isWorking == false })
+        //            }
+        //        }
+        //
+        //        func recursivelyWork(on:EventLoop) -> EventLoopFuture<Void> {
+        //            nextTask().flatMap { task in
+        //                on.flatSubmit {
+        //                    guard let task = task else { return on.makeSucceededVoidFuture() }
+        //                    self.doSomeWork(duration: task)
+        //                    return recursivelyWork(on: on)
+        //                }
+        //            }
+        //        }
+        //
+        //        let workExpectation = expectation(description: "waiting for work")
+        //
+        //        (0..<workers).compactMap { _ -> EventLoopFuture<Void> in
+        //            print("Deploying Worker")
+        //            return recursivelyWork(on: group.next())
+        //        }.flatten(on: mainLoop).whenComplete { result in
+        //            switch result {
+        //            case .failure(let error):
+        //                print("Error: \(error)")
+        //            case .success:
+        //                print("All done with work")
+        //                print(stuffToDo)
+        //            }
+        //            workExpectation.fulfill()
+        //        }
+        //
+        //        waitForExpectations(timeout: 120, handler: nil)
+        //        print("Shutting down event loop")
+        //        try! group.syncShutdownGracefully()
+        //    }
+
     }
-
-    @Sendable private func doSomeWork(duration: UInt32) {
-        usleep(duration)
-    }
-
-    //    class WorkerGroup {
-    //        let maxConcurrentWorkers:Int
-    //        let group:MultiThreadedEventLoopGroup
-    //        var tasks:[(Int) -> EventLoopFuture<[Int]>]
-    //    }
-
-    //    struct Worker {
-    //        let eventloop:EventLoop
-    //        var isWorking:Bool = false
-    //
-    //        mutating func markWorking(_ working:Bool) {
-    //            isWorking = working
-    //        }
-    //    }
-    //
-    //    /// This test spawns a group of workers that work on a single (thread protected) list of 'work'.
-    //    /// Each worker checks for work to be done, recursively, then performs the work on their own eventloop and returns when there is no more work to be done.
-    //    func testEventLoopGroupConcurrentWorkersSmart() throws {
-    //
-    //        let group = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
-    //
-    //        let maxWorkers:Int = 2
-    //        var workers:[Worker] = []
-    //
-    //        var stuffToDo:[(taskDuration:UInt32, processed:Bool)] = (0..<10).map { i -> (taskDuration:UInt32, processed:Bool) in
-    //            return (UInt32.random(in: 2...5), false)
-    //        }
-    //
-    //        let mainLoop = group.next()
-    //        let timeoutPerTask:TimeAmount = .seconds(6)
-    //        let timeoutPerGroup:TimeAmount = .minutes(1)
-    //
-    //        /// Create our workers
-    //        workers = (0..<maxWorkers).map { _ in Worker(eventloop: group.next()) }
-    //
-    //        func nextTask() -> EventLoopFuture<UInt32?> {
-    //            mainLoop.submit {
-    //                guard let next = stuffToDo.firstIndex(where: { $0.processed == false }) else { return nil }
-    //                print("Dequeing task \(next) for work")
-    //                stuffToDo[next].processed = true
-    //                return stuffToDo[next].taskDuration
-    //            }
-    //        }
-    //
-    //        func nextWorker() -> Worker? {
-    //            mainLoop.submit {
-    //                workers.first(where: { $0.isWorking == false })
-    //            }
-    //        }
-    //
-    //        func recursivelyWork(on:EventLoop) -> EventLoopFuture<Void> {
-    //            nextTask().flatMap { task in
-    //                on.flatSubmit {
-    //                    guard let task = task else { return on.makeSucceededVoidFuture() }
-    //                    self.doSomeWork(duration: task)
-    //                    return recursivelyWork(on: on)
-    //                }
-    //            }
-    //        }
-    //
-    //        let workExpectation = expectation(description: "waiting for work")
-    //
-    //        (0..<workers).compactMap { _ -> EventLoopFuture<Void> in
-    //            print("Deploying Worker")
-    //            return recursivelyWork(on: group.next())
-    //        }.flatten(on: mainLoop).whenComplete { result in
-    //            switch result {
-    //            case .failure(let error):
-    //                print("Error: \(error)")
-    //            case .success:
-    //                print("All done with work")
-    //                print(stuffToDo)
-    //            }
-    //            workExpectation.fulfill()
-    //        }
-    //
-    //        waitForExpectations(timeout: 120, handler: nil)
-    //        print("Shutting down event loop")
-    //        try! group.syncShutdownGracefully()
-    //    }
 
 }

--- a/Tests/LibP2PKadDHTTests/DHTKeyTests.swift
+++ b/Tests/LibP2PKadDHTTests/DHTKeyTests.swift
@@ -19,381 +19,393 @@ import Testing
 
 @testable import LibP2PKadDHT
 
-@Suite("DHT Key Tests")
-struct DHTKeyTests {
+extension LibP2PKadDHTTests {
 
-    @Test func testStuff() {
-        let node: UInt8 = 0b00001110
+    @Suite("DHT Key Tests")
+    struct DHTKeyTests {
 
-        let nodeA: UInt8 = 0b00001111
-        let nodeB: UInt8 = 0b00011110
-        let nodeC: UInt8 = 0b01010101
+        @Test func testStuff() {
+            let node: UInt8 = 0b00001110
 
-        let ordered = [nodeA, nodeB, nodeC]
-        var nodes = Array(ordered.reversed())
+            let nodeA: UInt8 = 0b00001111
+            let nodeB: UInt8 = 0b00011110
+            let nodeC: UInt8 = 0b01010101
 
-        #expect(nodes != ordered)
+            let ordered = [nodeA, nodeB, nodeC]
+            var nodes = Array(ordered.reversed())
 
-        /// Lets sort the nodes
-        nodes.sort(by: { closer(to: $0, than: $1, from: node) })
+            #expect(nodes != ordered)
 
-        #expect(nodes == ordered)
-    }
+            /// Lets sort the nodes
+            nodes.sort(by: { closer(to: $0, than: $1, from: node) })
 
-    @Test func testZeroPrefixLength() {
-        let byteArrays: [[UInt8]] = [
-            [0x00, 0x00, 0x00, 0x80, 0x00, 0x00, 0x00],
-            [0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00],
-            [0x00, 0x58, 0xFF, 0x80, 0x00, 0x00, 0xF0],
-        ]
-        let zeroLengths = [24, 56, 9]
-
-        for byteArray in byteArrays {
-            print(byteArray.commonPrefixLength(with: [0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]))
+            #expect(nodes == ordered)
         }
 
-        for bytes in byteArrays.enumerated() {
-            print("\(bytes.element.zeroPrefixLength()) == \(zeroLengths[bytes.offset])")
-            #expect(bytes.element.zeroPrefixLength() == zeroLengths[bytes.offset])
-        }
-    }
+        @Test func testZeroPrefixLength() {
+            let byteArrays: [[UInt8]] = [
+                [0x00, 0x00, 0x00, 0x80, 0x00, 0x00, 0x00],
+                [0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00],
+                [0x00, 0x58, 0xFF, 0x80, 0x00, 0x00, 0xF0],
+            ]
+            let zeroLengths = [24, 56, 9]
 
-    @Test func testXORKeySpace() {
-        let ids: [[UInt8]] = [
-            [0xFF, 0xFF, 0xFF, 0xFF],
-            [0x00, 0x00, 0x00, 0x00],
-            [0xFF, 0xFF, 0xFF, 0xF0],
-        ]
+            for byteArray in byteArrays {
+                print(byteArray.commonPrefixLength(with: [0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]))
+            }
 
-        let ks: [(KadDHT.Key, KadDHT.Key)] = [
-            (KadDHT.Key(ids[0]), KadDHT.Key(ids[0])),
-            (KadDHT.Key(ids[1]), KadDHT.Key(ids[1])),
-            (KadDHT.Key(ids[2]), KadDHT.Key(ids[2])),
-        ]
-
-        for (i, s) in ks.enumerated() {
-            /// Assert that the same bytes results in the same DHTKey each time
-            #expect(s.0 == s.1)
-
-            /// Assert that the original bytes we're modified
-            #expect(s.0.original == ids[i])
-
-            /// Assert that our SHA256 DHTKey is 32 bytes
-            #expect(s.0.bytes.count == 32)
+            for bytes in byteArrays.enumerated() {
+                print("\(bytes.element.zeroPrefixLength()) == \(zeroLengths[bytes.offset])")
+                #expect(bytes.element.zeroPrefixLength() == zeroLengths[bytes.offset])
+            }
         }
 
-        for (i, s) in ks.enumerated() {
-            if i == 0 { continue }
+        @Test func testXORKeySpace() {
+            let ids: [[UInt8]] = [
+                [0xFF, 0xFF, 0xFF, 0xFF],
+                [0x00, 0x00, 0x00, 0x00],
+                [0xFF, 0xFF, 0xFF, 0xF0],
+            ]
 
-            /// Ensure distance calc is symmetrical
-            print(
-                "Symmetrical Distance Calc: \(bytesToInt(s.0.distanceTo(key: ks[i-1].0))) | \(bytesToInt(ks[i-1].0.distanceTo(key: s.0)))"
-            )
-            #expect(s.0.distanceTo(key: ks[i - 1].0) == ks[i - 1].0.distanceTo(key: s.0))
+            let ks: [(KadDHT.Key, KadDHT.Key)] = [
+                (KadDHT.Key(ids[0]), KadDHT.Key(ids[0])),
+                (KadDHT.Key(ids[1]), KadDHT.Key(ids[1])),
+                (KadDHT.Key(ids[2]), KadDHT.Key(ids[2])),
+            ]
 
-            /// Ensure neighboring keys aren't equal to one another
-            #expect(s.0 != ks[i - 1].0)
+            for (i, s) in ks.enumerated() {
+                /// Assert that the same bytes results in the same DHTKey each time
+                #expect(s.0 == s.1)
+
+                /// Assert that the original bytes we're modified
+                #expect(s.0.original == ids[i])
+
+                /// Assert that our SHA256 DHTKey is 32 bytes
+                #expect(s.0.bytes.count == 32)
+            }
+
+            for (i, s) in ks.enumerated() {
+                if i == 0 { continue }
+
+                /// Ensure distance calc is symmetrical
+                print(
+                    "Symmetrical Distance Calc: \(bytesToInt(s.0.distanceTo(key: ks[i-1].0))) | \(bytesToInt(ks[i-1].0.distanceTo(key: s.0)))"
+                )
+                #expect(s.0.distanceTo(key: ks[i - 1].0) == ks[i - 1].0.distanceTo(key: s.0))
+
+                /// Ensure neighboring keys aren't equal to one another
+                #expect(s.0 != ks[i - 1].0)
+
+            }
 
         }
 
-    }
-
-    @Test func testDistanceAndCenterSorting() {
-        let byteArrays: [[UInt8]] = [
-            [
-                173, 149, 19, 27, 192, 183, 153, 192, 177, 175, 71, 127, 177, 79, 207, 38, 166, 169, 247, 96, 121, 228,
-                139, 240, 144, 172, 183, 232, 54, 123, 253, 14,
-            ],
-            [
-                223, 63, 97, 152, 4, 169, 47, 219, 64, 87, 25, 45, 196, 61, 215, 72, 234, 119, 138, 220, 82, 188, 73,
-                140, 232, 5, 36, 192, 20, 184, 17, 25,
-            ],
-            [
-                73, 176, 221, 176, 149, 143, 22, 42, 129, 124, 213, 114, 232, 95, 189, 154, 18, 3, 122, 132, 32, 199,
-                53, 185, 58, 157, 117, 78, 52, 146, 157, 127,
-            ],
-            [
-                73, 176, 221, 176, 149, 143, 22, 42, 129, 124, 213, 114, 232, 95, 189, 154, 18, 3, 122, 132, 32, 199,
-                53, 185, 58, 157, 117, 78, 52, 146, 157, 127,
-            ],
-            [
-                73, 176, 221, 176, 149, 143, 22, 42, 129, 124, 213, 114, 232, 95, 189, 154, 18, 3, 122, 132, 32, 199,
-                53, 185, 58, 157, 117, 78, 52, 146, 157, 126,
-            ],
-            [
-                73, 0, 221, 176, 149, 143, 22, 42, 129, 124, 213, 114, 232, 95, 189, 154, 18, 3, 122, 132, 32, 199, 53,
-                185, 58, 157, 117, 78, 52, 146, 157, 127,
-            ],
-        ]
-
-        let keys = byteArrays.map { KadDHT.Key(preHashedBytes: $0, keySpace: .xor) }
-
-        print(keys[2].bytes)
-        print(keys[3].bytes)
-        print(keys[2].distanceTo(key: keys[3]))
-        #expect(0 == bytesToInt(keys[2].distanceTo(key: keys[3])))
-
-        print(keys[2].distanceTo(key: keys[4]))
-        #expect(1 == bytesToInt(keys[2].distanceTo(key: keys[4])))
-
-        print(keys[2].distanceTo(key: keys[5]))
-
-        /// Sort the keys by distance with respect to keys[2]
-        let sorted = keys.sorted(
-            byDistanceToKey: KadDHT.Key(
-                preHashedBytes: [
-                    73, 176, 221, 176, 149, 143, 22, 42, 129, 124, 213, 114, 232, 95, 189, 154, 18, 3, 122, 132, 32,
-                    199, 53, 185, 58, 157, 117, 78, 52, 146, 157, 127,
+        @Test func testDistanceAndCenterSorting() {
+            let byteArrays: [[UInt8]] = [
+                [
+                    173, 149, 19, 27, 192, 183, 153, 192, 177, 175, 71, 127, 177, 79, 207, 38, 166, 169, 247, 96, 121,
+                    228,
+                    139, 240, 144, 172, 183, 232, 54, 123, 253, 14,
                 ],
-                keySpace: .xor
+                [
+                    223, 63, 97, 152, 4, 169, 47, 219, 64, 87, 25, 45, 196, 61, 215, 72, 234, 119, 138, 220, 82, 188,
+                    73,
+                    140, 232, 5, 36, 192, 20, 184, 17, 25,
+                ],
+                [
+                    73, 176, 221, 176, 149, 143, 22, 42, 129, 124, 213, 114, 232, 95, 189, 154, 18, 3, 122, 132, 32,
+                    199,
+                    53, 185, 58, 157, 117, 78, 52, 146, 157, 127,
+                ],
+                [
+                    73, 176, 221, 176, 149, 143, 22, 42, 129, 124, 213, 114, 232, 95, 189, 154, 18, 3, 122, 132, 32,
+                    199,
+                    53, 185, 58, 157, 117, 78, 52, 146, 157, 127,
+                ],
+                [
+                    73, 176, 221, 176, 149, 143, 22, 42, 129, 124, 213, 114, 232, 95, 189, 154, 18, 3, 122, 132, 32,
+                    199,
+                    53, 185, 58, 157, 117, 78, 52, 146, 157, 126,
+                ],
+                [
+                    73, 0, 221, 176, 149, 143, 22, 42, 129, 124, 213, 114, 232, 95, 189, 154, 18, 3, 122, 132, 32, 199,
+                    53,
+                    185, 58, 157, 117, 78, 52, 146, 157, 127,
+                ],
+            ]
+
+            let keys = byteArrays.map { KadDHT.Key(preHashedBytes: $0, keySpace: .xor) }
+
+            print(keys[2].bytes)
+            print(keys[3].bytes)
+            print(keys[2].distanceTo(key: keys[3]))
+            #expect(0 == bytesToInt(keys[2].distanceTo(key: keys[3])))
+
+            print(keys[2].distanceTo(key: keys[4]))
+            #expect(1 == bytesToInt(keys[2].distanceTo(key: keys[4])))
+
+            print(keys[2].distanceTo(key: keys[5]))
+
+            /// Sort the keys by distance with respect to keys[2]
+            let sorted = keys.sorted(
+                byDistanceToKey: KadDHT.Key(
+                    preHashedBytes: [
+                        73, 176, 221, 176, 149, 143, 22, 42, 129, 124, 213, 114, 232, 95, 189, 154, 18, 3, 122, 132, 32,
+                        199, 53, 185, 58, 157, 117, 78, 52, 146, 157, 127,
+                    ],
+                    keySpace: .xor
+                )
             )
-        )
-        let expectedOrder = [2, 3, 4, 5, 1, 0]
-        for item in sorted { print(item) }
+            let expectedOrder = [2, 3, 4, 5, 1, 0]
+            for item in sorted { print(item) }
 
-        for idx in expectedOrder.enumerated() {
-            #expect(keys[idx.element] == sorted[idx.offset])
-        }
-    }
-
-    @Test func testSumByteArray() throws {
-        let arr1 = try KadDHT.Key(PeerID(.Ed25519))
-        let arr2 = try KadDHT.Key(PeerID(.Ed25519))
-
-        print(arr1.bytes)
-        print("+")
-        print(arr2.bytes)
-        print(
-            "------------------------------------------------------------------------------------------------------------------------------"
-        )
-        var summation: [UInt8] = []
-        var carry: Bool = false
-        for (i, byte) in arr1.bytes.enumerated().reversed() {
-            let temp: UInt16 = UInt16(byte) + UInt16(arr2.bytes[i]) + (carry ? 1 : 0)
-            summation.insert(UInt8(temp % 256), at: 0)
-            if temp > 255 { carry = true } else { carry = false }
-        }
-        if carry { summation.insert(1, at: 0) }
-        print(summation)
-    }
-
-    @Test func testByteAddition() {
-        let five: UInt8 = 255
-        let four: UInt8 = 1
-
-        let sum: UInt16 = UInt16(five) + UInt16(four)
-        print(sum)
-        print(UInt8(sum % 256))
-    }
-
-    // The following KadDHT tests were lifted from https://github.com/jeanlauliac/kademlia-dht/blob/master/test/id.test.js
-    @Test func testKadDHTZeroKey() throws {
-        /// Defaults to 32 bytes
-        let id0 = KadDHT.Key.Zero
-        let stringRep = "0000000000000000000000000000000000000000000000000000000000000000"
-        let arrayRep: [UInt8] = [
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        ]
-
-        #expect(arrayRep.count == 32)
-        #expect(id0.bytes == arrayRep)
-        #expect(stringRep.count == 64)
-        #expect(id0.toString() == stringRep)
-
-        #expect(id0.bytes.asString(base: .base16) == id0.bytes.toHexString())
-    }
-
-    @Test func testKadDHTZeroKeyBits() throws {
-        /// Defaults to 32 bytes
-        let id0 = KadDHT.Key.Zero
-        let stringRep = "0000000000000000000000000000000000000000000000000000000000000000"
-        let arrayRep: [UInt8] = [
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        ]
-
-        #expect(arrayRep.count == 32)
-        #expect(id0.bytes == arrayRep)
-        #expect(stringRep.count == 64)
-        #expect(id0.toString() == stringRep)
-
-        #expect(arrayRep.commonPrefixLengthBits(with: id0.bytes) == 256)
-
-        #expect(id0.bytes.asString(base: .base16) == id0.bytes.toHexString())
-    }
-
-    /// Our KadDHT Implementation defaults to Sha256, in this test we use Sha1...
-    @Test func testkadDHTKeyFromString() throws {
-        let id0 = KadDHT.Key("the cake is a lie".bytes)
-
-        var hasher = SHA1()
-        let _ = try hasher.update(withBytes: "the cake is a lie".bytes)
-        let digest = try hasher.finish()
-
-        print(digest.toHexString())
-
-        #expect(digest.toHexString() == "4e13b0c28e17087366ac4d67801ae0835bf9e9a1")
-
-        print(id0.toHex())
-        print(id0.original.toHexString())
-    }
-
-    @Test func testkadDHTKeyDistance() throws {
-
-        var hasher = SHA1()
-        let _ = try hasher.update(withBytes: "the cake is a lie".bytes)
-        let digest = try hasher.finish()
-
-        let id1 = KadDHT.Key(preHashedBytes: digest)
-
-        /// Ensure distance to self yeilds zero
-        for byte in id1.distanceTo(key: id1) {
-            #expect(byte == 0)
+            for idx in expectedOrder.enumerated() {
+                #expect(keys[idx.element] == sorted[idx.offset])
+            }
         }
 
-        var hasher2 = SHA1()
-        let _ = try hasher2.update(withBytes: "fubar".bytes)
-        let digest2 = try hasher2.finish()
+        @Test func testSumByteArray() throws {
+            let arr1 = try KadDHT.Key(PeerID(.Ed25519))
+            let arr2 = try KadDHT.Key(PeerID(.Ed25519))
 
-        let id2 = KadDHT.Key(preHashedBytes: digest2)
-
-        let distance = "d4a6bfe55a3715cad428cedd03de6e39a04b43b6"
-
-        #expect(id1.distanceTo(key: id2).toHexString() == distance)
-    }
-
-    @Test func testCompareDistance() throws {
-        let id0 = KadDHT.Key(prefix: [0b001100101])
-        let id1 = KadDHT.Key(prefix: [0b011110011])
-        let id2 = KadDHT.Key(prefix: [0b001010101])
-
-        #expect(id0.compareDistancesFromSelf(to: id1, and: id2) == .secondKey)
-        #expect(id0.compareDistancesFromSelf(to: id2, and: id1) == .firstKey)
-        #expect(id0.compareDistancesFromSelf(to: id1, and: id1) == .sameDistance)
-    }
-
-    @Test func testkadDHTKeyEquality() throws {
-
-        var hasher = SHA1()
-        let _ = try hasher.update(withBytes: "the cake is a lie".bytes)
-        let digest = try hasher.finish()
-
-        let id1 = KadDHT.Key(preHashedBytes: digest)
-
-        /// Ensure distance to self yeilds zero
-        #expect(id1 == id1)
-
-        var hasher2 = SHA1()
-        let _ = try hasher2.update(withBytes: "fubar".bytes)
-        let digest2 = try hasher2.finish()
-
-        let id2 = KadDHT.Key(preHashedBytes: digest2)
-
-        #expect(id1 != id2)
-    }
-
-    @Test func testPeerIDDistance() throws {
-        let peerID = try PeerID()
-        print(peerID.hexString)
-
-        //var peers:[PeerID] = (0..<256).map { _ in try! PeerID(.Ed25519) }
-        //print(peers.map { $0.hexString })
-
-        let peers: [String] = (0..<8).map { SHA1().calculate(for: [UInt8](arrayLiteral: $0)).asString(base: .base16) }
-        print(peers)
-
-        //peers.forEach {
-        //    print( distanceBetween(p0: peerID, p1: $0) )
-        //}
-    }
-
-    /// SHA1 Distance Test
-    ///
-    /// This test...
-    /// 1) Generates 2048 Random SHA1 hashes,
-    /// 2) Sorts the set of hashes by distance to our main hash,
-    /// 3) Then calculates and prints the total distance for the 3 closest and 3 furthest hashes from our main hash
-    /// - Note: Generating and sorting 2048 SHA1 Hashes takes about 0.264 seconds
-    /// - Note: We use SHA1 here because the entropy is small enough we can notice distance results with a relatively low sample count.
-    /// PeerID's byte size is just too large to get any meaningful data without generating massive sample lists...
-    ///
-    /// An example of printing the KBucket Distance (20,000 SHA1 Hashes)
-    /// ```
-    /// 5ba93c9db0cff93f52b521d7420e43f6eda2784f // Our ID
-    /// Sorted Peer List (Closest to Furthest)
-    /// 5ba91b3606ad0d94e793ee7f37fc31a69664194d (43618452829355)       // Closest Match
-    /// 5bad77b85f86c014b329bcfa0f46d4b98e46f6d1 (1208526207269163)
-    /// 5ba3d2a92b7c68070570741471cca46462cefeeb (3076659485053240)
-    /// .
-    /// .
-    /// .
-    /// a447683cdd3e6b141098f4ec5a08eb42d69a065a (18441770576439775787)
-    /// a45a2afa9c482c5a66644b2ddc6b563fdd1ea1bf (18443109531396855141)
-    /// a453828f7fbc614d8ff260c84f9ecafd5cda44b5 (18445264211848435826) // Furthest Match
-    /// ^^^^^^^^^^^^^^^^^^
-    /// 43618452829355
-    /// 0
-    /// ,----------------------------------------,
-    /// | 0 | 0 | 0 | 0 | 0 | 0 | 1 | 71 | 19928 |
-    /// '----------------------------------------'
-    /// ```
-    @Test func testSHA1_ID_Distance() throws {
-        typealias Bytes = [UInt8]
-        typealias KBucket = [Int]
-
-        let ourID = SHA1().calculate(for: [0])
-        print(ourID.asString(base: .base58btc))
-
-        var peers: [Bytes] = (1...2000).map { _ in
-            SHA1().calculate(for: [UInt8](withUnsafeBytes(of: Int64.random(in: 1...Int64.max), { $0 })))
-        }
-        ///peers.shuffle()
-        //print("Unsorted Peer List")
-        //peers.forEach { print($0.asString(base: .base16)) }
-        //print("^^^^^^^^^^^^^^^^^^")
-
-        peers.sort { lhs, rhs in
-            compareDistances(from: ourID, to: lhs, and: rhs) == 1
+            print(arr1.bytes)
+            print("+")
+            print(arr2.bytes)
+            print(
+                "------------------------------------------------------------------------------------------------------------------------------"
+            )
+            var summation: [UInt8] = []
+            var carry: Bool = false
+            for (i, byte) in arr1.bytes.enumerated().reversed() {
+                let temp: UInt16 = UInt16(byte) + UInt16(arr2.bytes[i]) + (carry ? 1 : 0)
+                summation.insert(UInt8(temp % 256), at: 0)
+                if temp > 255 { carry = true } else { carry = false }
+            }
+            if carry { summation.insert(1, at: 0) }
+            print(summation)
         }
 
-        /// The list should now be sorted, closest to furthest
-        print("Sorted Peer List (Closest to Furthest)")
-        //        peers.forEach { key in
-        //            let dist = bytesToInt(distanceBetween(key: ourID, and: key))
-        //            print("\(key.asString(base: .base16)) (\(dist))")
-        //        }
-        for key in peers.prefix(3) {
-            let dist = bytesToInt(distanceBetween(key: ourID, and: key))
-            print("\(key.asString(base: .base58btc)) (\(dist)) (cpl: \(ourID.commonPrefixLength(with: key)))")
+        @Test func testByteAddition() {
+            let five: UInt8 = 255
+            let four: UInt8 = 1
+
+            let sum: UInt16 = UInt16(five) + UInt16(four)
+            print(sum)
+            print(UInt8(sum % 256))
         }
-        print(".\n.\n.\n")
-        for key in peers.suffix(3) {
-            let dist = bytesToInt(distanceBetween(key: ourID, and: key))
-            print("\(key.asString(base: .base58btc)) (\(dist)) (cpl: \(ourID.commonPrefixLength(with: key)))")
+
+        // The following KadDHT tests were lifted from https://github.com/jeanlauliac/kademlia-dht/blob/master/test/id.test.js
+        @Test func testKadDHTZeroKey() throws {
+            /// Defaults to 32 bytes
+            let id0 = KadDHT.Key.Zero
+            let stringRep = "0000000000000000000000000000000000000000000000000000000000000000"
+            let arrayRep: [UInt8] = [
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            ]
+
+            #expect(arrayRep.count == 32)
+            #expect(id0.bytes == arrayRep)
+            #expect(stringRep.count == 64)
+            #expect(id0.toString() == stringRep)
+
+            #expect(id0.bytes.asString(base: .base16) == id0.bytes.toHexString())
         }
-        print("^^^^^^^^^^^^^^^^^^")
 
-        let dist = distanceBetween(key: ourID, and: peers.first!)
-        print(bytesToInt(dist))
+        @Test func testKadDHTZeroKeyBits() throws {
+            /// Defaults to 32 bytes
+            let id0 = KadDHT.Key.Zero
+            let stringRep = "0000000000000000000000000000000000000000000000000000000000000000"
+            let arrayRep: [UInt8] = [
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            ]
 
-        let dist2 = bytesToInt(distanceBetween(key: ourID, and: ourID))
-        print(dist2)
-        #expect(dist2 == 0)
+            #expect(arrayRep.count == 32)
+            #expect(id0.bytes == arrayRep)
+            #expect(stringRep.count == 64)
+            #expect(id0.toString() == stringRep)
 
-        var bucket = KBucket(repeating: 0, count: 20)
-        for key in peers {
-            let dist = distanceBetween(key: ourID, and: key).zeroPrefixLength()
-            bucket[19 - dist] += 1
-            //if let idx = dist.prefix(8).firstIndex(where: { $0 != 0 } ) {
-            //    bucket[8-idx] += 1
-            //} else {
-            //    bucket[8] += 1
+            #expect(arrayRep.commonPrefixLengthBits(with: id0.bytes) == 256)
+
+            #expect(id0.bytes.asString(base: .base16) == id0.bytes.toHexString())
+        }
+
+        /// Our KadDHT Implementation defaults to Sha256, in this test we use Sha1...
+        @Test func testkadDHTKeyFromString() throws {
+            let id0 = KadDHT.Key("the cake is a lie".bytes)
+
+            var hasher = SHA1()
+            let _ = try hasher.update(withBytes: "the cake is a lie".bytes)
+            let digest = try hasher.finish()
+
+            print(digest.toHexString())
+
+            #expect(digest.toHexString() == "4e13b0c28e17087366ac4d67801ae0835bf9e9a1")
+
+            print(id0.toHex())
+            print(id0.original.toHexString())
+        }
+
+        @Test func testkadDHTKeyDistance() throws {
+
+            var hasher = SHA1()
+            let _ = try hasher.update(withBytes: "the cake is a lie".bytes)
+            let digest = try hasher.finish()
+
+            let id1 = KadDHT.Key(preHashedBytes: digest)
+
+            /// Ensure distance to self yeilds zero
+            for byte in id1.distanceTo(key: id1) {
+                #expect(byte == 0)
+            }
+
+            var hasher2 = SHA1()
+            let _ = try hasher2.update(withBytes: "fubar".bytes)
+            let digest2 = try hasher2.finish()
+
+            let id2 = KadDHT.Key(preHashedBytes: digest2)
+
+            let distance = "d4a6bfe55a3715cad428cedd03de6e39a04b43b6"
+
+            #expect(id1.distanceTo(key: id2).toHexString() == distance)
+        }
+
+        @Test func testCompareDistance() throws {
+            let id0 = KadDHT.Key(prefix: [0b001100101])
+            let id1 = KadDHT.Key(prefix: [0b011110011])
+            let id2 = KadDHT.Key(prefix: [0b001010101])
+
+            #expect(id0.compareDistancesFromSelf(to: id1, and: id2) == .secondKey)
+            #expect(id0.compareDistancesFromSelf(to: id2, and: id1) == .firstKey)
+            #expect(id0.compareDistancesFromSelf(to: id1, and: id1) == .sameDistance)
+        }
+
+        @Test func testkadDHTKeyEquality() throws {
+
+            var hasher = SHA1()
+            let _ = try hasher.update(withBytes: "the cake is a lie".bytes)
+            let digest = try hasher.finish()
+
+            let id1 = KadDHT.Key(preHashedBytes: digest)
+
+            /// Ensure distance to self yeilds zero
+            #expect(id1 == id1)
+
+            var hasher2 = SHA1()
+            let _ = try hasher2.update(withBytes: "fubar".bytes)
+            let digest2 = try hasher2.finish()
+
+            let id2 = KadDHT.Key(preHashedBytes: digest2)
+
+            #expect(id1 != id2)
+        }
+
+        @Test func testPeerIDDistance() throws {
+            let peerID = try PeerID()
+            print(peerID.hexString)
+
+            //var peers:[PeerID] = (0..<256).map { _ in try! PeerID(.Ed25519) }
+            //print(peers.map { $0.hexString })
+
+            let peers: [String] = (0..<8).map {
+                SHA1().calculate(for: [UInt8](arrayLiteral: $0)).asString(base: .base16)
+            }
+            print(peers)
+
+            //peers.forEach {
+            //    print( distanceBetween(p0: peerID, p1: $0) )
             //}
         }
 
-        let bucketString = bucket.map { "\($0)" }.joined(separator: " | ")
-        print(",\(String(repeating: "-", count: bucketString.count + 2)),")
-        print("| \(bucketString) |")
-        print("'\(String(repeating: "-", count: bucketString.count + 2))'")
+        /// SHA1 Distance Test
+        ///
+        /// This test...
+        /// 1) Generates 2048 Random SHA1 hashes,
+        /// 2) Sorts the set of hashes by distance to our main hash,
+        /// 3) Then calculates and prints the total distance for the 3 closest and 3 furthest hashes from our main hash
+        /// - Note: Generating and sorting 2048 SHA1 Hashes takes about 0.264 seconds
+        /// - Note: We use SHA1 here because the entropy is small enough we can notice distance results with a relatively low sample count.
+        /// PeerID's byte size is just too large to get any meaningful data without generating massive sample lists...
+        ///
+        /// An example of printing the KBucket Distance (20,000 SHA1 Hashes)
+        /// ```
+        /// 5ba93c9db0cff93f52b521d7420e43f6eda2784f // Our ID
+        /// Sorted Peer List (Closest to Furthest)
+        /// 5ba91b3606ad0d94e793ee7f37fc31a69664194d (43618452829355)       // Closest Match
+        /// 5bad77b85f86c014b329bcfa0f46d4b98e46f6d1 (1208526207269163)
+        /// 5ba3d2a92b7c68070570741471cca46462cefeeb (3076659485053240)
+        /// .
+        /// .
+        /// .
+        /// a447683cdd3e6b141098f4ec5a08eb42d69a065a (18441770576439775787)
+        /// a45a2afa9c482c5a66644b2ddc6b563fdd1ea1bf (18443109531396855141)
+        /// a453828f7fbc614d8ff260c84f9ecafd5cda44b5 (18445264211848435826) // Furthest Match
+        /// ^^^^^^^^^^^^^^^^^^
+        /// 43618452829355
+        /// 0
+        /// ,----------------------------------------,
+        /// | 0 | 0 | 0 | 0 | 0 | 0 | 1 | 71 | 19928 |
+        /// '----------------------------------------'
+        /// ```
+        @Test func testSHA1_ID_Distance() throws {
+            typealias Bytes = [UInt8]
+            typealias KBucket = [Int]
+
+            let ourID = SHA1().calculate(for: [0])
+            print(ourID.asString(base: .base58btc))
+
+            var peers: [Bytes] = (1...2000).map { _ in
+                SHA1().calculate(for: [UInt8](withUnsafeBytes(of: Int64.random(in: 1...Int64.max), { $0 })))
+            }
+            ///peers.shuffle()
+            //print("Unsorted Peer List")
+            //peers.forEach { print($0.asString(base: .base16)) }
+            //print("^^^^^^^^^^^^^^^^^^")
+
+            peers.sort { lhs, rhs in
+                compareDistances(from: ourID, to: lhs, and: rhs) == 1
+            }
+
+            /// The list should now be sorted, closest to furthest
+            print("Sorted Peer List (Closest to Furthest)")
+            //        peers.forEach { key in
+            //            let dist = bytesToInt(distanceBetween(key: ourID, and: key))
+            //            print("\(key.asString(base: .base16)) (\(dist))")
+            //        }
+            for key in peers.prefix(3) {
+                let dist = bytesToInt(distanceBetween(key: ourID, and: key))
+                print("\(key.asString(base: .base58btc)) (\(dist)) (cpl: \(ourID.commonPrefixLength(with: key)))")
+            }
+            print(".\n.\n.\n")
+            for key in peers.suffix(3) {
+                let dist = bytesToInt(distanceBetween(key: ourID, and: key))
+                print("\(key.asString(base: .base58btc)) (\(dist)) (cpl: \(ourID.commonPrefixLength(with: key)))")
+            }
+            print("^^^^^^^^^^^^^^^^^^")
+
+            let dist = distanceBetween(key: ourID, and: peers.first!)
+            print(bytesToInt(dist))
+
+            let dist2 = bytesToInt(distanceBetween(key: ourID, and: ourID))
+            print(dist2)
+            #expect(dist2 == 0)
+
+            var bucket = KBucket(repeating: 0, count: 20)
+            for key in peers {
+                let dist = distanceBetween(key: ourID, and: key).zeroPrefixLength()
+                bucket[19 - dist] += 1
+                //if let idx = dist.prefix(8).firstIndex(where: { $0 != 0 } ) {
+                //    bucket[8-idx] += 1
+                //} else {
+                //    bucket[8] += 1
+                //}
+            }
+
+            let bucketString = bucket.map { "\($0)" }.joined(separator: " | ")
+            print(",\(String(repeating: "-", count: bucketString.count + 2)),")
+            print("| \(bucketString) |")
+            print("'\(String(repeating: "-", count: bucketString.count + 2))'")
+        }
+
     }
 
 }

--- a/Tests/LibP2PKadDHTTests/ExternalNetworkTests.swift
+++ b/Tests/LibP2PKadDHTTests/ExternalNetworkTests.swift
@@ -19,468 +19,474 @@ import Testing
 
 @testable import LibP2PKadDHT
 
-@Suite("External Network Tests", .externalIntegrationTestsEnabled, .serialized)
-final class ExternalNetworkTests {
+extension LibP2PKadDHTTests {
 
-    /// ********************************************
-    ///    Testing External KadDHT - Heartbeat
-    /// ********************************************
-    ///
-    /// This test manually triggers one KadDHT heartbeat that kicks off a FindNode lookup for our libp2p PeerID
-    /// A heartbeat / node lookup takes about 22 secs and discovers about 20 peers...
-    /// 📒 --------------------------------- 📒
-    /// Routing Table [<peer.ID PiV5bE>]
-    /// Bucket Count: 1 buckets of size: 20
-    /// Total Peers: 20
-    /// b[0] = [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0]
-    /// ---------------------------------------
-    /// 2 heartbeats --> Time:  48 seconds,  Mem: 12.5 --> 13.8,  CPU: 0-12%,  Peers: 28
-    /// 📒 --------------------------------- 📒
-    /// Routing Table [<peer.ID PiV5bE>]
-    /// Bucket Count: 2 buckets of size: 20
-    /// Total Peers: 28
-    /// b[0] = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
-    /// b[1] = [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
-    /// ---------------------------------------
-    /// 3 heartbeats --> Time:  59 seconds,  Mem: 12.5 --> 14.5,  CPU: 0-12%,  Peers: 27
-    @Test(.disabled())
-    func testLibP2PKadDHT_SingleHeartbeat() throws {
-        /// Init the libp2p node
-        let lib = try makeHost()
+    @Suite("External Network Tests", .externalIntegrationTestsEnabled, .serialized)
+    final class ExternalNetworkTests {
 
-        /// Start the node
-        try lib.start()
+        /// ********************************************
+        ///    Testing External KadDHT - Heartbeat
+        /// ********************************************
+        ///
+        /// This test manually triggers one KadDHT heartbeat that kicks off a FindNode lookup for our libp2p PeerID
+        /// A heartbeat / node lookup takes about 22 secs and discovers about 20 peers...
+        /// 📒 --------------------------------- 📒
+        /// Routing Table [<peer.ID PiV5bE>]
+        /// Bucket Count: 1 buckets of size: 20
+        /// Total Peers: 20
+        /// b[0] = [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0]
+        /// ---------------------------------------
+        /// 2 heartbeats --> Time:  48 seconds,  Mem: 12.5 --> 13.8,  CPU: 0-12%,  Peers: 28
+        /// 📒 --------------------------------- 📒
+        /// Routing Table [<peer.ID PiV5bE>]
+        /// Bucket Count: 2 buckets of size: 20
+        /// Total Peers: 28
+        /// b[0] = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+        /// b[1] = [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+        /// ---------------------------------------
+        /// 3 heartbeats --> Time:  59 seconds,  Mem: 12.5 --> 14.5,  CPU: 0-12%,  Peers: 27
+        @Test(.disabled())
+        func testLibP2PKadDHT_SingleHeartbeat() throws {
+            /// Init the libp2p node
+            let lib = try makeHost()
 
-        /// Do your test stuff ...
-        #expect(lib.dht.kadDHT.state == .started)
+            /// Start the node
+            try lib.start()
 
-        //let exp = expectation(description: "Wait for response")
-        print("*** Before Lookup ***")
-        print(lib.dht.kadDHT.peerstore)
-        print("")
+            /// Do your test stuff ...
+            #expect(lib.dht.kadDHT.state == .started)
 
-        print("*** Before Lookup ***")
-        lib.peers.dumpAll()
-        print("")
+            //let exp = expectation(description: "Wait for response")
+            print("*** Before Lookup ***")
+            print(lib.dht.kadDHT.peerstore)
+            print("")
 
-        for _ in (0..<1) {
-            /// Trigger a heartbeat (which will perform a peer lookup for our peerID)
-            try lib.dht.kadDHT.heartbeat().wait()
+            print("*** Before Lookup ***")
+            lib.peers.dumpAll()
+            print("")
+
+            for _ in (0..<1) {
+                /// Trigger a heartbeat (which will perform a peer lookup for our peerID)
+                try lib.dht.kadDHT.heartbeat().wait()
+
+                sleep(2)
+            }
+
+            print("*** After Lookup ***")
+            print("(DHT Peerstore: \(try lib.dht.kadDHT.peerstore.count().wait()) - \(lib.dht.kadDHT.peerstore)")
+            print("")
+
+            print("")
+            lib.peers.dumpAll()
+            print("")
+
+            print("Connections: ")
+            print(try lib.connections.getConnections(on: nil).wait())
+
+            print("*** History ***")
+            lib.connections.dumpConnectionHistory()
+
+            print("*** Metrics ***")
+            for hist in lib.dht.kadDHT.metrics.history { print(hist.event) }
+
+            print("*** Routing Table ***")
+            print(lib.dht.kadDHT.routingTable)
 
             sleep(2)
+
+            /// Stop the node
+            lib.shutdown()
+
+            print("All Done!")
         }
 
-        print("*** After Lookup ***")
-        print("(DHT Peerstore: \(try lib.dht.kadDHT.peerstore.count().wait()) - \(lib.dht.kadDHT.peerstore)")
-        print("")
+        /// 20 heartbeats --> Time:  415 seconds,  Mem: 17.2,  CPU: 0-20%,  Peers: 170
+        /// 📒 --------------------------------- 📒
+        /// Routing Table [<peer.ID LFMPqX>]
+        /// Bucket Count: 8 buckets of size: 20
+        /// Total Peers: 99
+        /// b[0] = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+        /// b[1] = [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+        /// b[2] = [2, 2, 2, 2, 2, 2, 2, 2, 2, 2]
+        /// b[3] = []
+        /// b[4] = [4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4]
+        /// b[5] = [5, 5, 5, 5, 5, 5]
+        /// b[6] = [6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6]
+        /// b[7] = [14, 9, 10, 9, 9, 9, 10, 10, 10, 10, 10, 10, 11, 11, 11, 12, 13]
+        /// ---------------------------------------
+        @Test(.disabled())
+        func testLibP2PKadDHT_SingleHeartbeat_Async() async throws {
+            /// Init the libp2p node
+            let lib = try makeHost()
 
-        print("")
-        lib.peers.dumpAll()
-        print("")
+            /// Start the node
+            try await lib.startup()
 
-        print("Connections: ")
-        print(try lib.connections.getConnections(on: nil).wait())
+            /// Do your test stuff ...
+            #expect(lib.dht.kadDHT.state == .started)
 
-        print("*** History ***")
-        lib.connections.dumpConnectionHistory()
+            print("*** Before Lookup ***")
+            print(lib.dht.kadDHT.peerstore)
+            print("")
 
-        print("*** Metrics ***")
-        for hist in lib.dht.kadDHT.metrics.history { print(hist.event) }
+            print("*** Before Lookup ***")
+            lib.peers.dumpAll()
+            print("")
 
-        print("*** Routing Table ***")
-        print(lib.dht.kadDHT.routingTable)
+            for _ in (0..<20) {
+                /// Trigger a heartbeat (which will perform a peer lookup for our peerID)
+                try await lib.dht.kadDHT.heartbeat().get()
 
-        sleep(2)
+                try await Task.sleep(for: .seconds(1))
+            }
 
-        /// Stop the node
-        lib.shutdown()
+            print("*** After Lookup ***")
+            print("(DHT Peerstore: \(try await lib.dht.kadDHT.peerstore.count().get()) - \(lib.dht.kadDHT.peerstore)")
+            print("")
 
-        print("All Done!")
-    }
+            print("")
+            lib.peers.dumpAll()
+            print("")
 
-    /// 20 heartbeats --> Time:  415 seconds,  Mem: 17.2,  CPU: 0-20%,  Peers: 170
-    /// 📒 --------------------------------- 📒
-    /// Routing Table [<peer.ID LFMPqX>]
-    /// Bucket Count: 8 buckets of size: 20
-    /// Total Peers: 99
-    /// b[0] = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
-    /// b[1] = [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
-    /// b[2] = [2, 2, 2, 2, 2, 2, 2, 2, 2, 2]
-    /// b[3] = []
-    /// b[4] = [4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4]
-    /// b[5] = [5, 5, 5, 5, 5, 5]
-    /// b[6] = [6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6]
-    /// b[7] = [14, 9, 10, 9, 9, 9, 10, 10, 10, 10, 10, 10, 11, 11, 11, 12, 13]
-    /// ---------------------------------------
-    @Test(.disabled())
-    func testLibP2PKadDHT_SingleHeartbeat_Async() async throws {
-        /// Init the libp2p node
-        let lib = try makeHost()
+            print("Connections: ")
+            for conn in try await lib.connections.getConnections(on: nil).get() {
+                print("\(conn)")
+            }
 
-        /// Start the node
-        try await lib.startup()
+            print("*** History ***")
+            lib.connections.dumpConnectionHistory()
 
-        /// Do your test stuff ...
-        #expect(lib.dht.kadDHT.state == .started)
+            print("*** Metrics ***")
+            for hist in lib.dht.kadDHT.metrics.history { print(hist.event) }
 
-        print("*** Before Lookup ***")
-        print(lib.dht.kadDHT.peerstore)
-        print("")
+            print("*** Routing Table ***")
+            print(lib.dht.kadDHT.routingTable)
 
-        print("*** Before Lookup ***")
-        lib.peers.dumpAll()
-        print("")
+            try await Task.sleep(for: .milliseconds(50))
 
-        for _ in (0..<20) {
-            /// Trigger a heartbeat (which will perform a peer lookup for our peerID)
-            try await lib.dht.kadDHT.heartbeat().get()
-
-            try await Task.sleep(for: .seconds(1))
+            /// Stop the node
+            try await lib.asyncShutdown()
         }
 
-        print("*** After Lookup ***")
-        print("(DHT Peerstore: \(try await lib.dht.kadDHT.peerstore.count().get()) - \(lib.dht.kadDHT.peerstore)")
-        print("")
+        /// ******************************************************
+        ///    Testing External KadDHT - Single Query - GetValue
+        /// ******************************************************
+        ///
+        /// - For getValue(key: )
+        ///   - let key = try "/pk/".bytes + CID("QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ").multihash.value
+        @Test(.disabled())
+        func testLibP2PKadDHT_DirectPing() throws {
+            /// Init the libp2p node
+            let lib = try makeHost()
 
-        print("")
-        lib.peers.dumpAll()
-        print("")
+            /// Start the node
+            try lib.start()
 
-        print("Connections: ")
-        for conn in try await lib.connections.getConnections(on: nil).get() {
-            print("\(conn)")
-        }
+            /// Do your test stuff ...
+            #expect(lib.dht.kadDHT.state == .started)
 
-        print("*** History ***")
-        lib.connections.dumpConnectionHistory()
-
-        print("*** Metrics ***")
-        for hist in lib.dht.kadDHT.metrics.history { print(hist.event) }
-
-        print("*** Routing Table ***")
-        print(lib.dht.kadDHT.routingTable)
-
-        try await Task.sleep(for: .milliseconds(50))
-
-        /// Stop the node
-        try await lib.asyncShutdown()
-    }
-
-    /// ******************************************************
-    ///    Testing External KadDHT - Single Query - GetValue
-    /// ******************************************************
-    ///
-    /// - For getValue(key: )
-    ///   - let key = try "/pk/".bytes + CID("QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ").multihash.value
-    @Test(.disabled())
-    func testLibP2PKadDHT_DirectPing() throws {
-        /// Init the libp2p node
-        let lib = try makeHost()
-
-        /// Start the node
-        try lib.start()
-
-        /// Do your test stuff ...
-        #expect(lib.dht.kadDHT.state == .started)
-
-        let bootstrapPeer = PeerInfo(
-            peer: try PeerID(cid: "QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ"),
-            addresses: [
-                try Multiaddr("/ip4/104.131.131.82/tcp/4001/p2p/QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ")
-            ]
-        )
-
-        let response = try lib.dht.kadDHT._sendQuery(.ping, to: bootstrapPeer).wait()
-        print(response)
-
-        sleep(2)
-
-        /// Stop the node
-        lib.shutdown()
-
-        print("All Done!")
-    }
-
-    /// ******************************************************
-    ///    Testing External KadDHT - Single Query - GetValue
-    /// ******************************************************
-    ///
-    /// - For getValue(key: )
-    ///   - let key = try "/pk/".bytes + CID("QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ").multihash.value
-    @Test(.disabled())
-    func testLibP2PKadDHT_GetValueQuery() throws {
-        /// Init the libp2p node
-        let lib = try makeHost()
-
-        /// Start the node
-        try lib.start()
-
-        /// Do your test stuff ...
-        #expect(lib.dht.kadDHT.state == .started)
-
-        // This doesn't work... we need to find an actual value to query...
-        //let key = try "/ipfs/".bytes + CID("QmXuNFLZc6Nb5akB4sZsxK3doShsFKT1sZFvxLXJvZQwAW").multihash.value // Doesnt work
-        //let key = try "/ipfs/".bytes + CID("QmSnuWmxptJZdLJpKRarxBMS2Ju2oANVrgbr2xWbie9b2D").multihash.value // Doesnt work
-        let key = try "/ipfs/".bytes + CID("QmdmQXB2mzChmMeKY47C43LxUdg1NDJ5MWcKMKxDu7RgQm").multihash.value
-
-        //let key = try "/pk/".bytes + CID(peerID).multihash.value
-
-        let val = try lib.dht.kadDHT.getUsingLookupList(key).wait()
-        print(val ?? "NIL")
-
-        sleep(2)
-
-        /// Stop the node
-        lib.shutdown()
-
-        print("All Done!")
-    }
-
-    /// ******************************************************
-    ///    Testing External KadDHT - Single Query - GetValue
-    /// ******************************************************
-    ///
-    /// - For getValue(key: )
-    ///   - let key = try "/pk/".bytes + CID("QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ").multihash.value
-    @Test(.disabled())
-    func testLibP2PKadDHT_GetValueQuery_PeerRecord() throws {
-        /// Init the libp2p node
-        let lib = try makeHost()
-
-        /// Start the node
-        try lib.start()
-
-        /// Do your test stuff ...
-        #expect(lib.dht.kadDHT.state == .started)
-
-        //let peerID = "QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN" // nil
-        //let peerID = "QmcZf59bWwK5XFi76CZX8cbJ4BhTzzA3gU1ZjYZcYW3dwt" // nil
-        //let peerID = "QmQCU2EcMqAqQPR2i9bChDtGNJchTbq5TbXJJ16u19uLTa" // nil
-        let peerID = "QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ"  // Success
-        //let peerID = "QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb" // nil
-
-        let key = try "/pk/".bytes + PeerID(cid: peerID).id
-
-        print("/pk/ => \("/pk/".bytes)")
-        print("\(peerID) => \(try PeerID(cid: peerID).id)")
-
-        let val = try lib.dht.kadDHT.getUsingLookupList(key).wait()
-        //let _ = try lib.identify.ping(peer: PeerID(cid: "QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ")).wait()
-
-        #expect(val != nil)
-        if let val = val {
-            print(try val.toProtobuf().serializedData().toHexString())
-            print("DHT Record")
-            print("Key (Hex): \(val.key.byteArray)")
-            print("Value (Hex): \(val.value.byteArray)")
-            print("Time Received: \(val.timeReceived)")
-            #expect(try PeerID(marshaledPublicKey: val.value).b58String == peerID)
-        } else {
-            print("NIL")
-        }
-
-        sleep(2)
-
-        lib.peers.dumpAll()
-
-        sleep(2)
-
-        /// Stop the node
-        lib.shutdown()
-
-        print("All Done!")
-    }
-
-    /// **********************************************************
-    ///    Testing Internal KadDHT - Single Query - FindProvider
-    /// **********************************************************
-    ///
-    /// - For findProvider(cid: )
-    ///   - let key = try CID("QmXuNFLZc6Nb5akB4sZsxK3doShsFKT1sZFvxLXJvZQwAW").multihash.value (results in found providers)
-    @Test(.disabled())
-    func testLibP2PKadDHT_FindProviderQuery() throws {
-        /// Init the libp2p node
-        let lib = try makeHost()
-
-        /// Prepare our expectations
-        //let expectationNode1ReceivedNode2Subscription = expectation(description: "Node1 received fruit subscription from Node2")
-
-        /// Start the node
-        try lib.start()
-
-        /// Do your test stuff ...
-        #expect(lib.dht.kadDHT.state == .started)
-
-        /// Attempt to find providers of the following CID
-        //let key = try CID("QmXuNFLZc6Nb5akB4sZsxK3doShsFKT1sZFvxLXJvZQwAW").multihash.value
-        //let key = try CID("QmdSn5nS2toXqj5jKGvpsoNJjk2rofY6ctk7RY86t6KeMS").multihash.value
-        let key = try CID("QmdmQXB2mzChmMeKY47C43LxUdg1NDJ5MWcKMKxDu7RgQm").multihash.value  // XKCD Archives
-        //let key = try CID("Qmdp4pcmePccsVHedMC4CsSnkEtXLXT2N3go7S8qeLg3RY").multihash.value  // 101 - Laser Scope
-        let val = try lib.dht.kadDHT.getProvidersUsingLookupList(key).wait()
-        print("--- Providers For \(key.toBase64()) ---")
-        print(val)
-        print("----------------------------")
-        #expect(val.isEmpty == false)
-
-        /// Stop the node
-        lib.shutdown()
-
-        print("All Done!")
-    }
-
-    /// **********************************************************
-    ///    Testing Internal KadDHT - Single Query - Provide
-    /// **********************************************************
-    ///
-    /// - For findProvider(cid: )
-    ///   - let key = try CID("QmXuNFLZc6Nb5akB4sZsxK3doShsFKT1sZFvxLXJvZQwAW").multihash.value (results in found providers)
-    @Test(.disabled())
-    func testLibP2PKadDHT_Provide() throws {
-        /// Init the libp2p node
-        let lib = try makeHost()
-
-        /// Start the node
-        try lib.start()
-
-        /// Do your test stuff ...
-        #expect(lib.dht.kadDHT.state == .started)
-
-        /// Create a Public Key Record using our nodes PeerID
-
-        //let df = ISO8601DateFormatter()
-        //df.formatOptions.insert(.withFractionalSeconds)
-
-        let key = "/pk/".bytes + lib.peerID.id
-        //        let record = try DHT.Record.with { rec in
-        //            rec.key = Data(key)
-        //            rec.value = try Data(lib.peerID.marshalPublicKey())
-        //            rec.timeReceived = df.string(from: Date())
-        //        }
-
-        let record = try KadDHT.createPubKeyRecord(peerID: lib.peerID)
-
-        /// Attempt to store the Public Key Record on the DHT
-        let val = try lib.dht.kadDHT.storeNew(key, value: record).wait()
-        print(val)
-        /// Peer: 12D3KooWRo5HnaS7zJJH9MfaZUJE7UQB4FPVNQYiGT3xbdzPTm6V
-        /// Peer: QmPxcrHKPUDQtP9EKsvCkDdvFvt2iiY7AnWygumZP9kzhc
-        /// 12D3KooWGirPF2sNqCFYaXuWhPF27hSLdCYER725kLfz2rxer4Sy
-        /// QmZ9JkSfELePivfpG6fXk7cU1Zu95VCQhKbQafpZt6ZkDX
-
-        sleep(5)
-
-        /// Attempt to retrieve the Public Key Record from the DHT
-        let pubKeyRecord = try lib.dht.kadDHT.getUsingLookupList(key).wait()
-        print(pubKeyRecord ?? "NIL")
-        /// peer.ID Ro5Hna
-        /// peer.ID PxcrHK
-        /// peer.ID GirPF2
-        /// peer.ID Z9JkSf
-
-        sleep(2)
-
-        /// Stop the node
-        lib.shutdown()
-
-        print("All Done!")
-    }
-
-    /// **************************************************************
-    ///    Testing External KadDHT - Single Heartbeat - w/ Topology
-    /// **************************************************************
-    ///
-    @Test(.disabled())
-    func testLibP2PKadDHT_SingleHeartbeat_Topology() throws {
-        /// Init the libp2p node
-        let lib = try makeHost()
-
-        /// Start the node
-        try lib.start()
-
-        /// Do your test stuff ...
-        #expect(lib.dht.kadDHT.state == .started)
-
-        lib.topology.register(
-            TopologyRegistration(
-                protocol: "/meshsub/1.0.0",
-                handler: TopologyHandler(onConnect: { peerID, conn in
-                    print("⭐️ Found a /meshsub/1.0.0 \(peerID)")
-                })
+            let bootstrapPeer = PeerInfo(
+                peer: try PeerID(cid: "QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ"),
+                addresses: [
+                    try Multiaddr("/ip4/104.131.131.82/tcp/4001/p2p/QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ")
+                ]
             )
-        )
 
-        //let exp = expectation(description: "Wait for response")
-        print("*** Before Lookup ***")
-        print(lib.dht.kadDHT.peerstore)
-        print("")
-
-        print("*** Before Lookup ***")
-        lib.peers.dumpAll()
-        print("")
-
-        for _ in (0..<3) {
-            /// Trigger a heartbeat (which will perform a peer lookup for our peerID)
-            try lib.dht.kadDHT.heartbeat().wait()
+            let response = try lib.dht.kadDHT._sendQuery(.ping, to: bootstrapPeer).wait()
+            print(response)
 
             sleep(2)
+
+            /// Stop the node
+            lib.shutdown()
+
+            print("All Done!")
         }
 
-        print("*** After Lookup ***")
-        print("(DHT Peerstore: \(try lib.dht.kadDHT.peerstore.count().wait()) - \(lib.dht.kadDHT.peerstore)")
-        print("")
+        /// ******************************************************
+        ///    Testing External KadDHT - Single Query - GetValue
+        /// ******************************************************
+        ///
+        /// - For getValue(key: )
+        ///   - let key = try "/pk/".bytes + CID("QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ").multihash.value
+        @Test(.disabled())
+        func testLibP2PKadDHT_GetValueQuery() throws {
+            /// Init the libp2p node
+            let lib = try makeHost()
 
-        print("*** After Lookup ***")
-        let pAll = try lib.peers.all().wait()
-        //print("(Libp2p Peerstore: \(pAll.count)) - \(pAll.map { "\($0.id)\nMultiaddr: [\($0.addresses.map { $0.description }.joined(separator: ",\n"))]\nProtocols: [\($0.protocols.map { $0.stringValue }.joined(separator: ",\n"))]\nMetadata: \($0.metadata.map { "\($0.key): \(String(data: Data($0.value), encoding: .utf8) ?? "NIL")" }.joined(separator: ",\n"))" }.joined(separator: "\n\n"))")
-        print(pAll.map { "\($0)" }.joined(separator: "\n"))
-        print("")
-        print("Total Peers in PeerStore: \(try lib.peers.count().wait())")
-        //lib.peers.dumpAll()
-        print("")
+            /// Start the node
+            try lib.start()
 
-        print("Connections: ")
-        print(try lib.connections.getConnections(on: nil).wait())
+            /// Do your test stuff ...
+            #expect(lib.dht.kadDHT.state == .started)
 
-        print("*** Metrics ***")
-        for hist in lib.dht.kadDHT.metrics.history { print(hist.event) }
+            // This doesn't work... we need to find an actual value to query...
+            //let key = try "/ipfs/".bytes + CID("QmXuNFLZc6Nb5akB4sZsxK3doShsFKT1sZFvxLXJvZQwAW").multihash.value // Doesnt work
+            //let key = try "/ipfs/".bytes + CID("QmSnuWmxptJZdLJpKRarxBMS2Ju2oANVrgbr2xWbie9b2D").multihash.value // Doesnt work
+            let key = try "/ipfs/".bytes + CID("QmdmQXB2mzChmMeKY47C43LxUdg1NDJ5MWcKMKxDu7RgQm").multihash.value
 
-        print("*** Routing Table ***")
-        print(lib.dht.kadDHT.routingTable)
+            //let key = try "/pk/".bytes + CID(peerID).multihash.value
 
-        //waitForExpectations(timeout: 10, handler: nil)
-        sleep(2)
+            let val = try lib.dht.kadDHT.getUsingLookupList(key).wait()
+            print(val ?? "NIL")
 
-        /// Stop the node
-        lib.shutdown()
+            sleep(2)
 
-        print("All Done!")
+            /// Stop the node
+            lib.shutdown()
+
+            print("All Done!")
+        }
+
+        /// ******************************************************
+        ///    Testing External KadDHT - Single Query - GetValue
+        /// ******************************************************
+        ///
+        /// - For getValue(key: )
+        ///   - let key = try "/pk/".bytes + CID("QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ").multihash.value
+        @Test(.disabled())
+        func testLibP2PKadDHT_GetValueQuery_PeerRecord() throws {
+            /// Init the libp2p node
+            let lib = try makeHost()
+
+            /// Start the node
+            try lib.start()
+
+            /// Do your test stuff ...
+            #expect(lib.dht.kadDHT.state == .started)
+
+            //let peerID = "QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN" // nil
+            //let peerID = "QmcZf59bWwK5XFi76CZX8cbJ4BhTzzA3gU1ZjYZcYW3dwt" // nil
+            //let peerID = "QmQCU2EcMqAqQPR2i9bChDtGNJchTbq5TbXJJ16u19uLTa" // nil
+            let peerID = "QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ"  // Success
+            //let peerID = "QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb" // nil
+
+            let key = try "/pk/".bytes + PeerID(cid: peerID).id
+
+            print("/pk/ => \("/pk/".bytes)")
+            print("\(peerID) => \(try PeerID(cid: peerID).id)")
+
+            let val = try lib.dht.kadDHT.getUsingLookupList(key).wait()
+            //let _ = try lib.identify.ping(peer: PeerID(cid: "QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ")).wait()
+
+            #expect(val != nil)
+            if let val = val {
+                print(try val.toProtobuf().serializedData().toHexString())
+                print("DHT Record")
+                print("Key (Hex): \(val.key.byteArray)")
+                print("Value (Hex): \(val.value.byteArray)")
+                print("Time Received: \(val.timeReceived)")
+                #expect(try PeerID(marshaledPublicKey: val.value).b58String == peerID)
+            } else {
+                print("NIL")
+            }
+
+            sleep(2)
+
+            lib.peers.dumpAll()
+
+            sleep(2)
+
+            /// Stop the node
+            lib.shutdown()
+
+            print("All Done!")
+        }
+
+        /// **********************************************************
+        ///    Testing Internal KadDHT - Single Query - FindProvider
+        /// **********************************************************
+        ///
+        /// - For findProvider(cid: )
+        ///   - let key = try CID("QmXuNFLZc6Nb5akB4sZsxK3doShsFKT1sZFvxLXJvZQwAW").multihash.value (results in found providers)
+        @Test(.disabled())
+        func testLibP2PKadDHT_FindProviderQuery() throws {
+            /// Init the libp2p node
+            let lib = try makeHost()
+
+            /// Prepare our expectations
+            //let expectationNode1ReceivedNode2Subscription = expectation(description: "Node1 received fruit subscription from Node2")
+
+            /// Start the node
+            try lib.start()
+
+            /// Do your test stuff ...
+            #expect(lib.dht.kadDHT.state == .started)
+
+            /// Attempt to find providers of the following CID
+            //let key = try CID("QmXuNFLZc6Nb5akB4sZsxK3doShsFKT1sZFvxLXJvZQwAW").multihash.value
+            //let key = try CID("QmdSn5nS2toXqj5jKGvpsoNJjk2rofY6ctk7RY86t6KeMS").multihash.value
+            let key = try CID("QmdmQXB2mzChmMeKY47C43LxUdg1NDJ5MWcKMKxDu7RgQm").multihash.value  // XKCD Archives
+            //let key = try CID("Qmdp4pcmePccsVHedMC4CsSnkEtXLXT2N3go7S8qeLg3RY").multihash.value  // 101 - Laser Scope
+            let val = try lib.dht.kadDHT.getProvidersUsingLookupList(key).wait()
+            print("--- Providers For \(key.toBase64()) ---")
+            print(val)
+            print("----------------------------")
+            #expect(val.isEmpty == false)
+
+            /// Stop the node
+            lib.shutdown()
+
+            print("All Done!")
+        }
+
+        /// **********************************************************
+        ///    Testing Internal KadDHT - Single Query - Provide
+        /// **********************************************************
+        ///
+        /// - For findProvider(cid: )
+        ///   - let key = try CID("QmXuNFLZc6Nb5akB4sZsxK3doShsFKT1sZFvxLXJvZQwAW").multihash.value (results in found providers)
+        @Test(.disabled())
+        func testLibP2PKadDHT_Provide() throws {
+            /// Init the libp2p node
+            let lib = try makeHost()
+
+            /// Start the node
+            try lib.start()
+
+            /// Do your test stuff ...
+            #expect(lib.dht.kadDHT.state == .started)
+
+            /// Create a Public Key Record using our nodes PeerID
+
+            //let df = ISO8601DateFormatter()
+            //df.formatOptions.insert(.withFractionalSeconds)
+
+            let key = "/pk/".bytes + lib.peerID.id
+            //        let record = try DHT.Record.with { rec in
+            //            rec.key = Data(key)
+            //            rec.value = try Data(lib.peerID.marshalPublicKey())
+            //            rec.timeReceived = df.string(from: Date())
+            //        }
+
+            let record = try KadDHT.createPubKeyRecord(peerID: lib.peerID)
+
+            /// Attempt to store the Public Key Record on the DHT
+            let val = try lib.dht.kadDHT.storeNew(key, value: record).wait()
+            print(val)
+            /// Peer: 12D3KooWRo5HnaS7zJJH9MfaZUJE7UQB4FPVNQYiGT3xbdzPTm6V
+            /// Peer: QmPxcrHKPUDQtP9EKsvCkDdvFvt2iiY7AnWygumZP9kzhc
+            /// 12D3KooWGirPF2sNqCFYaXuWhPF27hSLdCYER725kLfz2rxer4Sy
+            /// QmZ9JkSfELePivfpG6fXk7cU1Zu95VCQhKbQafpZt6ZkDX
+
+            sleep(5)
+
+            /// Attempt to retrieve the Public Key Record from the DHT
+            let pubKeyRecord = try lib.dht.kadDHT.getUsingLookupList(key).wait()
+            print(pubKeyRecord ?? "NIL")
+            /// peer.ID Ro5Hna
+            /// peer.ID PxcrHK
+            /// peer.ID GirPF2
+            /// peer.ID Z9JkSf
+
+            sleep(2)
+
+            /// Stop the node
+            lib.shutdown()
+
+            print("All Done!")
+        }
+
+        /// **************************************************************
+        ///    Testing External KadDHT - Single Heartbeat - w/ Topology
+        /// **************************************************************
+        ///
+        @Test(.disabled())
+        func testLibP2PKadDHT_SingleHeartbeat_Topology() throws {
+            /// Init the libp2p node
+            let lib = try makeHost()
+
+            /// Start the node
+            try lib.start()
+
+            /// Do your test stuff ...
+            #expect(lib.dht.kadDHT.state == .started)
+
+            lib.topology.register(
+                TopologyRegistration(
+                    protocol: "/meshsub/1.0.0",
+                    handler: TopologyHandler(onConnect: { peerID, conn in
+                        print("⭐️ Found a /meshsub/1.0.0 \(peerID)")
+                    })
+                )
+            )
+
+            //let exp = expectation(description: "Wait for response")
+            print("*** Before Lookup ***")
+            print(lib.dht.kadDHT.peerstore)
+            print("")
+
+            print("*** Before Lookup ***")
+            lib.peers.dumpAll()
+            print("")
+
+            for _ in (0..<3) {
+                /// Trigger a heartbeat (which will perform a peer lookup for our peerID)
+                try lib.dht.kadDHT.heartbeat().wait()
+
+                sleep(2)
+            }
+
+            print("*** After Lookup ***")
+            print("(DHT Peerstore: \(try lib.dht.kadDHT.peerstore.count().wait()) - \(lib.dht.kadDHT.peerstore)")
+            print("")
+
+            print("*** After Lookup ***")
+            let pAll = try lib.peers.all().wait()
+            //print("(Libp2p Peerstore: \(pAll.count)) - \(pAll.map { "\($0.id)\nMultiaddr: [\($0.addresses.map { $0.description }.joined(separator: ",\n"))]\nProtocols: [\($0.protocols.map { $0.stringValue }.joined(separator: ",\n"))]\nMetadata: \($0.metadata.map { "\($0.key): \(String(data: Data($0.value), encoding: .utf8) ?? "NIL")" }.joined(separator: ",\n"))" }.joined(separator: "\n\n"))")
+            print(pAll.map { "\($0)" }.joined(separator: "\n"))
+            print("")
+            print("Total Peers in PeerStore: \(try lib.peers.count().wait())")
+            //lib.peers.dumpAll()
+            print("")
+
+            print("Connections: ")
+            print(try lib.connections.getConnections(on: nil).wait())
+
+            print("*** Metrics ***")
+            for hist in lib.dht.kadDHT.metrics.history { print(hist.event) }
+
+            print("*** Routing Table ***")
+            print(lib.dht.kadDHT.routingTable)
+
+            //waitForExpectations(timeout: 10, handler: nil)
+            sleep(2)
+
+            /// Stop the node
+            lib.shutdown()
+
+            print("All Done!")
+        }
+
+        var nextPort: Int = 10000
+        private func makeHost(
+            mode: KadDHT.Mode = .client,
+            options: KadDHT.NodeOptions = .default,
+            bootstrapPeers: [PeerInfo] = BootstrapPeerDiscovery.IPFSBootNodes,
+            autoHeartbeat: Bool = false,
+            usingGroup: Application.EventLoopGroupProvider = .singleton
+        ) throws -> Application {
+            let lib = try Application(.testing, peerID: PeerID(.Ed25519), eventLoopGroupProvider: usingGroup)
+            lib.security.use(.noise)
+            lib.muxers.use(.yamux)
+            lib.dht.use(
+                .kadDHT(mode: mode, options: options, bootstrapPeers: bootstrapPeers, autoUpdate: autoHeartbeat)
+            )
+            lib.servers.use(.tcp(host: "127.0.0.1", port: nextPort))
+
+            //lib.connectionManager.use(connectionType: BasicConnectionLight.self)
+
+            //try lib.peers.add(peerInfo: PeerInfo(
+            //    peer: PeerID(cid: "QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN"),
+            //    addresses: [Multiaddr("/ip4/139.178.91.71/tcp/4001/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN")]
+            //))
+
+            nextPort += 1
+
+            lib.logger.logLevel = .notice  //.trace
+
+            return lib
+        }
     }
 
-    var nextPort: Int = 10000
-    private func makeHost(
-        mode: KadDHT.Mode = .client,
-        options: KadDHT.NodeOptions = .default,
-        bootstrapPeers: [PeerInfo] = BootstrapPeerDiscovery.IPFSBootNodes,
-        autoHeartbeat: Bool = false,
-        usingGroup: Application.EventLoopGroupProvider = .singleton
-    ) throws -> Application {
-        let lib = try Application(.testing, peerID: PeerID(.Ed25519), eventLoopGroupProvider: usingGroup)
-        lib.security.use(.noise)
-        lib.muxers.use(.yamux)
-        lib.dht.use(.kadDHT(mode: mode, options: options, bootstrapPeers: bootstrapPeers, autoUpdate: autoHeartbeat))
-        lib.servers.use(.tcp(host: "127.0.0.1", port: nextPort))
-
-        //lib.connectionManager.use(connectionType: BasicConnectionLight.self)
-
-        //try lib.peers.add(peerInfo: PeerInfo(
-        //    peer: PeerID(cid: "QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN"),
-        //    addresses: [Multiaddr("/ip4/139.178.91.71/tcp/4001/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN")]
-        //))
-
-        nextPort += 1
-
-        lib.logger.logLevel = .notice  //.trace
-
-        return lib
-    }
 }

--- a/Tests/LibP2PKadDHTTests/InternalNetworkTests.swift
+++ b/Tests/LibP2PKadDHTTests/InternalNetworkTests.swift
@@ -22,389 +22,395 @@ import Testing
 
 @testable import LibP2PKadDHT
 
-@Suite("Internal Network Tests", .serialized)
-final class InternalNetworkTests {
+extension LibP2PKadDHTTests {
 
-    @Test(.internalIntegrationTestsEnabled)
-    func testInternalNetwork_PeerRouting() throws {
-        let dhtParams = KadDHT.NodeOptions(
-            connectionTimeout: .milliseconds(150),
-            maxConcurrentConnections: 3,
-            bucketSize: 5,
-            maxPeers: 15,
-            maxKeyValueStoreEntries: 10,
-            supportLocalNetwork: true
-        )
+    @Suite("Internal Network Tests", .internalIntegrationTestsEnabled, .serialized)
+    final class InternalNetworkTests {
 
-        let group: MultiThreadedEventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
-        defer { try! group.syncShutdownGracefully() }
+        @Test(.internalIntegrationTestsEnabled)
+        func testInternalNetwork_PeerRouting() throws {
+            let dhtParams = KadDHT.NodeOptions(
+                connectionTimeout: .milliseconds(150),
+                maxConcurrentConnections: 3,
+                bucketSize: 5,
+                maxPeers: 15,
+                maxKeyValueStoreEntries: 10,
+                supportLocalNetwork: true
+            )
 
-        let node1 = try makeHost(
-            mode: .server,
-            options: dhtParams,
-            bootstrapPeers: [],
-            autoHeartbeat: false,
-            usingGroup: .shared(group)
-        )
-        let node2 = try makeHost(
-            mode: .server,
-            options: dhtParams,
-            bootstrapPeers: [node1.peerInfo],
-            autoHeartbeat: false,
-            usingGroup: .shared(group)
-        )
-        let node3 = try makeHost(
-            mode: .server,
-            options: dhtParams,
-            bootstrapPeers: [node2.peerInfo],
-            autoHeartbeat: false,
-            usingGroup: .shared(group)
-        )
-        let node4 = try makeHost(
-            mode: .server,
-            options: dhtParams,
-            bootstrapPeers: [node3.peerInfo],
-            autoHeartbeat: false,
-            usingGroup: .shared(group)
-        )
+            let group: MultiThreadedEventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
+            defer { try! group.syncShutdownGracefully() }
 
-        try node1.start()
-        try node2.start()
-        try node3.start()
-        try node4.start()
-
-        // Ensure Node4 can find Node1 via Node2 & Node3
-        //peerRouting.findPeer(peer: node1.peerID)
-        let peer = try #require(try? node4.dht.kadDHT.findPeer(peer: node1.peerID).wait())
-        #expect(peer.peer == node1.peerID)
-        #expect(peer.addresses == node1.listenAddresses)
-
-        node1.shutdown()
-        node2.shutdown()
-        node3.shutdown()
-        node4.shutdown()
-
-        print("All Done!")
-    }
-
-    //    @Test(.internalIntegrationTestsEnabled)
-    //    func testInternalNetwork_ContentRouting() throws {
-    //        let dhtParams = KadDHT.NodeOptions(connectionTimeout: .seconds(5), maxConcurrentConnections: 3, bucketSize: 5, maxPeers: 15, maxKeyValueStoreEntries: 10)
-    //
-    //        let node1 = try makeHost(mode: .server, options: dhtParams, bootstrapPeers: [], autoHeartbeat: false)
-    //        let node2 = try makeHost(mode: .server, options: dhtParams, bootstrapPeers: [PeerInfo(peer: node1.peerID, addresses: node1.listenAddresses)], autoHeartbeat: false)
-    //        let node3 = try makeHost(mode: .server, options: dhtParams, bootstrapPeers: [PeerInfo(peer: node2.peerID, addresses: node2.listenAddresses)], autoHeartbeat: false)
-    //
-    //        try node1.start()
-    //        try node2.start()
-    //        try node3.start()
-    //
-    //        sleep(1)
-    //
-    //        let provide = try node1.contentRouting.provide(CID()).wait()
-    //
-    //        // Ensure Node3 can find Node1
-    //        let found = try node3.contentRouting.findProviders(cid: CID())
-    //
-    //        sleep(2)
-    //
-    //        nodes.forEach { $0.shutdown() }
-    //
-    //        print("All Done!")
-    //    }
-
-    @Test(.internalIntegrationTestsEnabled)
-    func testInternalNetwork() throws {
-        let group = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
-        defer { try! group.syncShutdownGracefully() }
-
-        let numberOfNodes = 4
-        let dhtParams = KadDHT.NodeOptions(
-            connectionTimeout: .milliseconds(150),
-            maxConcurrentConnections: 3,
-            bucketSize: 3,
-            maxPeers: 8,
-            maxKeyValueStoreEntries: 10,
-            supportLocalNetwork: true
-        )
-        var nodes: [Application] = try [
-            makeHost(
+            let node1 = try makeHost(
                 mode: .server,
                 options: dhtParams,
                 bootstrapPeers: [],
                 autoHeartbeat: false,
                 usingGroup: .shared(group)
             )
-        ]
-        for i in 1..<numberOfNodes {
-            try nodes.append(
-                self.makeHost(
-                    mode: .server,
-                    options: dhtParams,
-                    bootstrapPeers: [nodes[i - 1].peerInfo],
-                    autoHeartbeat: false,
-                    usingGroup: .shared(group)
-                )
-            )
-        }
-
-        // Register the `fruit` namespace with each node
-        for node in nodes {
-            try node.dht.kadDHT.handle(
-                namespace: "fruit",
-                validator: KadDHT.BaseValidator(
-                    validationFunction: { key, value in
-                        guard !key.isEmpty else { throw NSError(domain: "Invalid Fruit Message", code: 0) }
-                    },
-                    selectFunction: { key, values in
-                        0
-                    }
-                )
-            ).wait()
-        }
-
-        // Boot each node
-        for node in nodes { try node.start() }
-
-        // Add the last nodes info to the first node
-        try nodes[0].peers.add(peerInfo: nodes.last!.peerInfo).wait()
-
-        for node in nodes {
-            try node.dht.kadDHT.heartbeat().wait()
-        }
-
-        for node in nodes {
-            try node.dht.kadDHT.heartbeat().wait()
-        }
-
-        //printNetwork(nodes.map { $0.dht.kadDHT })
-
-        let item1Key = "/fruit/".bytes + Digest.sha256("apple".bytes)
-        let item1Record = DHT.Record.with {
-            $0.key = Data(item1Key)
-            $0.value = Data("🍎".utf8)
-        }
-
-        let storeAttempt1 = try nodes[0].dht.kadDHT.storeNew(item1Key, value: item1Record).wait()
-        #expect(storeAttempt1)
-
-        for node in nodes {
-            try node.dht.kadDHT.heartbeat().wait()
-        }
-
-        let storeAttempt2 = try nodes[0].dht.kadDHT.storeNew(item1Key, value: item1Record).wait()
-        #expect(storeAttempt2)
-
-        // Ensure the other nodes can retrieve the value
-        var successes = 0
-        for i in 0..<numberOfNodes {
-            let getAttempt2 = try nodes[i].dht.kadDHT.getUsingLookupList(item1Key).wait()
-            //print(getAttempt2 ?? "NIL")
-            if getAttempt2 != nil { successes += 1 }
-            #expect(getAttempt2 != nil)
-            #expect(getAttempt2?.key == Data(item1Key))
-            #expect(getAttempt2?.value == Data("🍎".utf8))
-        }
-        #expect(
-            successes == numberOfNodes,
-            "\(numberOfNodes - successes)/\(numberOfNodes) Nodes were unable to retrieve the value"
-        )
-
-        //for i in (0..<numberOfNodes) {
-        //let peerCount = try nodes[i].peers.count().wait()
-        //print("Node[\(i)]::PeerCount == \(peerCount)")
-        //}
-
-        //printNetwork(nodes.map { $0.dht.kadDHT })
-
-        for node in nodes { node.shutdown() }
-
-        print("All Done!")
-    }
-
-    @Test(.internalIntegrationTestsEnabled)
-    func testInternalNetwork_SortingTest() throws {
-        let group = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
-        defer { try! group.syncShutdownGracefully() }
-
-        let numberOfNodes = 20
-        let dhtParams = KadDHT.NodeOptions(
-            connectionTimeout: .milliseconds(150),
-            maxConcurrentConnections: 3,
-            bucketSize: 8,
-            maxPeers: 20,
-            maxKeyValueStoreEntries: 10,
-            supportLocalNetwork: true
-        )
-        var nodes: [Application] = try [
-            makeHost(
+            let node2 = try makeHost(
                 mode: .server,
                 options: dhtParams,
-                bootstrapPeers: [],
+                bootstrapPeers: [node1.peerInfo],
                 autoHeartbeat: false,
                 usingGroup: .shared(group)
             )
-        ]
-        for i in 1..<numberOfNodes {
-            try nodes.append(
-                self.makeHost(
+            let node3 = try makeHost(
+                mode: .server,
+                options: dhtParams,
+                bootstrapPeers: [node2.peerInfo],
+                autoHeartbeat: false,
+                usingGroup: .shared(group)
+            )
+            let node4 = try makeHost(
+                mode: .server,
+                options: dhtParams,
+                bootstrapPeers: [node3.peerInfo],
+                autoHeartbeat: false,
+                usingGroup: .shared(group)
+            )
+
+            try node1.start()
+            try node2.start()
+            try node3.start()
+            try node4.start()
+
+            // Ensure Node4 can find Node1 via Node2 & Node3
+            //peerRouting.findPeer(peer: node1.peerID)
+            let peer = try #require(try? node4.dht.kadDHT.findPeer(peer: node1.peerID).wait())
+            #expect(peer.peer == node1.peerID)
+            #expect(peer.addresses == node1.listenAddresses)
+
+            node1.shutdown()
+            node2.shutdown()
+            node3.shutdown()
+            node4.shutdown()
+
+            print("All Done!")
+        }
+
+        //    @Test(.internalIntegrationTestsEnabled)
+        //    func testInternalNetwork_ContentRouting() throws {
+        //        let dhtParams = KadDHT.NodeOptions(connectionTimeout: .seconds(5), maxConcurrentConnections: 3, bucketSize: 5, maxPeers: 15, maxKeyValueStoreEntries: 10)
+        //
+        //        let node1 = try makeHost(mode: .server, options: dhtParams, bootstrapPeers: [], autoHeartbeat: false)
+        //        let node2 = try makeHost(mode: .server, options: dhtParams, bootstrapPeers: [PeerInfo(peer: node1.peerID, addresses: node1.listenAddresses)], autoHeartbeat: false)
+        //        let node3 = try makeHost(mode: .server, options: dhtParams, bootstrapPeers: [PeerInfo(peer: node2.peerID, addresses: node2.listenAddresses)], autoHeartbeat: false)
+        //
+        //        try node1.start()
+        //        try node2.start()
+        //        try node3.start()
+        //
+        //        sleep(1)
+        //
+        //        let provide = try node1.contentRouting.provide(CID()).wait()
+        //
+        //        // Ensure Node3 can find Node1
+        //        let found = try node3.contentRouting.findProviders(cid: CID())
+        //
+        //        sleep(2)
+        //
+        //        nodes.forEach { $0.shutdown() }
+        //
+        //        print("All Done!")
+        //    }
+
+        @Test(.internalIntegrationTestsEnabled)
+        func testInternalNetwork() throws {
+            let group = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
+            defer { try! group.syncShutdownGracefully() }
+
+            let numberOfNodes = 4
+            let dhtParams = KadDHT.NodeOptions(
+                connectionTimeout: .milliseconds(150),
+                maxConcurrentConnections: 3,
+                bucketSize: 3,
+                maxPeers: 8,
+                maxKeyValueStoreEntries: 10,
+                supportLocalNetwork: true
+            )
+            var nodes: [Application] = try [
+                makeHost(
                     mode: .server,
                     options: dhtParams,
-                    bootstrapPeers: [nodes[i - 1].peerInfo],
+                    bootstrapPeers: [],
                     autoHeartbeat: false,
                     usingGroup: .shared(group)
                 )
-            )
-        }
+            ]
+            for i in 1..<numberOfNodes {
+                try nodes.append(
+                    self.makeHost(
+                        mode: .server,
+                        options: dhtParams,
+                        bootstrapPeers: [nodes[i - 1].peerInfo],
+                        autoHeartbeat: false,
+                        usingGroup: .shared(group)
+                    )
+                )
+            }
 
-        // Boot each node
-        for node in nodes { try node.start() }
+            // Register the `fruit` namespace with each node
+            for node in nodes {
+                try node.dht.kadDHT.handle(
+                    namespace: "fruit",
+                    validator: KadDHT.BaseValidator(
+                        validationFunction: { key, value in
+                            guard !key.isEmpty else { throw NSError(domain: "Invalid Fruit Message", code: 0) }
+                        },
+                        selectFunction: { key, values in
+                            0
+                        }
+                    )
+                ).wait()
+            }
 
-        // Add the last nodes info to the first node
-        try nodes[0].peers.add(peerInfo: nodes.last!.peerInfo).wait()
+            // Boot each node
+            for node in nodes { try node.start() }
 
-        for _ in 0..<5 {
+            // Add the last nodes info to the first node
+            try nodes[0].peers.add(peerInfo: nodes.last!.peerInfo).wait()
+
             for node in nodes {
                 try node.dht.kadDHT.heartbeat().wait()
             }
 
-            printNetwork(nodes.map { $0.dht.kadDHT })
+            for node in nodes {
+                try node.dht.kadDHT.heartbeat().wait()
+            }
+
+            //printNetwork(nodes.map { $0.dht.kadDHT })
+
+            let item1Key = "/fruit/".bytes + Digest.sha256("apple".bytes)
+            let item1Record = DHT.Record.with {
+                $0.key = Data(item1Key)
+                $0.value = Data("🍎".utf8)
+            }
+
+            let storeAttempt1 = try nodes[0].dht.kadDHT.storeNew(item1Key, value: item1Record).wait()
+            #expect(storeAttempt1)
+
+            for node in nodes {
+                try node.dht.kadDHT.heartbeat().wait()
+            }
+
+            let storeAttempt2 = try nodes[0].dht.kadDHT.storeNew(item1Key, value: item1Record).wait()
+            #expect(storeAttempt2)
+
+            // Ensure the other nodes can retrieve the value
+            var successes = 0
+            for i in 0..<numberOfNodes {
+                let getAttempt2 = try nodes[i].dht.kadDHT.getUsingLookupList(item1Key).wait()
+                //print(getAttempt2 ?? "NIL")
+                if getAttempt2 != nil { successes += 1 }
+                #expect(getAttempt2 != nil)
+                #expect(getAttempt2?.key == Data(item1Key))
+                #expect(getAttempt2?.value == Data("🍎".utf8))
+            }
+            #expect(
+                successes == numberOfNodes,
+                "\(numberOfNodes - successes)/\(numberOfNodes) Nodes were unable to retrieve the value"
+            )
+
+            //for i in (0..<numberOfNodes) {
+            //let peerCount = try nodes[i].peers.count().wait()
+            //print("Node[\(i)]::PeerCount == \(peerCount)")
+            //}
+
+            //printNetwork(nodes.map { $0.dht.kadDHT })
+
+            for node in nodes { node.shutdown() }
+
+            print("All Done!")
         }
 
-        for i in 0..<numberOfNodes {
-            let peerCount = try nodes[i].peers.count().wait()
-            #expect(peerCount >= numberOfNodes / 2)
+        @Test(.internalIntegrationTestsEnabled)
+        func testInternalNetwork_SortingTest() throws {
+            let group = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
+            defer { try! group.syncShutdownGracefully() }
+
+            let numberOfNodes = 20
+            let dhtParams = KadDHT.NodeOptions(
+                connectionTimeout: .milliseconds(150),
+                maxConcurrentConnections: 3,
+                bucketSize: 8,
+                maxPeers: 20,
+                maxKeyValueStoreEntries: 10,
+                supportLocalNetwork: true
+            )
+            var nodes: [Application] = try [
+                makeHost(
+                    mode: .server,
+                    options: dhtParams,
+                    bootstrapPeers: [],
+                    autoHeartbeat: false,
+                    usingGroup: .shared(group)
+                )
+            ]
+            for i in 1..<numberOfNodes {
+                try nodes.append(
+                    self.makeHost(
+                        mode: .server,
+                        options: dhtParams,
+                        bootstrapPeers: [nodes[i - 1].peerInfo],
+                        autoHeartbeat: false,
+                        usingGroup: .shared(group)
+                    )
+                )
+            }
+
+            // Boot each node
+            for node in nodes { try node.start() }
+
+            // Add the last nodes info to the first node
+            try nodes[0].peers.add(peerInfo: nodes.last!.peerInfo).wait()
+
+            for _ in 0..<5 {
+                for node in nodes {
+                    try node.dht.kadDHT.heartbeat().wait()
+                }
+
+                printNetwork(nodes.map { $0.dht.kadDHT })
+            }
+
+            for i in 0..<numberOfNodes {
+                let peerCount = try nodes[i].peers.count().wait()
+                #expect(peerCount >= numberOfNodes / 2)
+            }
+
+            for node in nodes { node.shutdown() }
+
+            print("All Done!")
         }
 
-        for node in nodes { node.shutdown() }
+        @Test(.internalIntegrationTestsEnabled)
+        func testInternalNetwork_Beacon() throws {
+            let group = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
+            defer { try! group.syncShutdownGracefully() }
 
-        print("All Done!")
-    }
-
-    @Test(.internalIntegrationTestsEnabled)
-    func testInternalNetwork_Beacon() throws {
-        let group = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
-        defer { try! group.syncShutdownGracefully() }
-
-        let numberOfNodes = 4
-        let dhtParams = KadDHT.NodeOptions(
-            connectionTimeout: .milliseconds(150),
-            maxConcurrentConnections: 3,
-            bucketSize: 3,
-            maxPeers: 8,
-            maxKeyValueStoreEntries: 10,
-            supportLocalNetwork: true
-        )
-        let beaconNode = try makeHost(
-            mode: .server,
-            options: dhtParams,
-            bootstrapPeers: [],
-            autoHeartbeat: false,
-            usingGroup: .shared(group)
-        )
-        let nodes = try (0..<numberOfNodes).map { _ in
-            try makeHost(
+            let numberOfNodes = 4
+            let dhtParams = KadDHT.NodeOptions(
+                connectionTimeout: .milliseconds(150),
+                maxConcurrentConnections: 3,
+                bucketSize: 3,
+                maxPeers: 8,
+                maxKeyValueStoreEntries: 10,
+                supportLocalNetwork: true
+            )
+            let beaconNode = try makeHost(
                 mode: .server,
                 options: dhtParams,
-                bootstrapPeers: [beaconNode.peerInfo],
+                bootstrapPeers: [],
                 autoHeartbeat: false,
                 usingGroup: .shared(group)
             )
-        }
-
-        /// Register the `fruit` namespace with each node
-        for node in ([beaconNode] + nodes) {
-            try node.dht.kadDHT.handle(
-                namespace: "fruit",
-                validator: KadDHT.BaseValidator(
-                    validationFunction: { key, value in
-                        guard !key.isEmpty else { throw NSError(domain: "Invalid Fruit Message", code: 0) }
-                    },
-                    selectFunction: { key, values in
-                        0
-                    }
+            let nodes = try (0..<numberOfNodes).map { _ in
+                try makeHost(
+                    mode: .server,
+                    options: dhtParams,
+                    bootstrapPeers: [beaconNode.peerInfo],
+                    autoHeartbeat: false,
+                    usingGroup: .shared(group)
                 )
-            ).wait()
+            }
+
+            /// Register the `fruit` namespace with each node
+            for node in ([beaconNode] + nodes) {
+                try node.dht.kadDHT.handle(
+                    namespace: "fruit",
+                    validator: KadDHT.BaseValidator(
+                        validationFunction: { key, value in
+                            guard !key.isEmpty else { throw NSError(domain: "Invalid Fruit Message", code: 0) }
+                        },
+                        selectFunction: { key, values in
+                            0
+                        }
+                    )
+                ).wait()
+            }
+
+            try beaconNode.start()
+            for node in nodes { try node.start() }
+
+            for node in nodes {
+                try node.dht.kadDHT.heartbeat().wait()
+            }
+
+            try beaconNode.dht.kadDHT.heartbeat().wait()
+
+            let item1Key = "/fruit/".bytes + Digest.sha256("apple".bytes)
+            let item1Record = DHT.Record.with {
+                $0.key = Data(item1Key)
+                $0.value = Data("🍎".utf8)
+            }
+
+            let storeAttempt1 = try nodes[0].dht.kadDHT.storeNew(item1Key, value: item1Record).wait()
+            #expect(storeAttempt1)
+
+            for node in nodes {
+                try node.dht.kadDHT.heartbeat().wait()
+            }
+
+            try beaconNode.dht.kadDHT.heartbeat().wait()
+
+            let storeAttempt2 = try nodes[0].dht.kadDHT.storeNew(item1Key, value: item1Record).wait()
+            #expect(storeAttempt2)
+
+            // Ensure the beacon node can retrieve the value
+            let getAttempt1 = try beaconNode.dht.kadDHT.getUsingLookupList(item1Key).wait()
+            #expect(getAttempt1 != nil)
+            #expect(getAttempt1?.key == Data(item1Key))
+            #expect(getAttempt1?.value == Data("🍎".utf8))
+
+            // Ensure the other nodes can retrieve the value
+            var successes = getAttempt1 == nil ? 0 : 1
+            for i in 1..<numberOfNodes {
+                let getAttempt2 = try nodes[i].dht.kadDHT.getUsingLookupList(item1Key).wait()
+                if getAttempt2 != nil { successes += 1 }
+                #expect(getAttempt2 != nil)
+                #expect(getAttempt2?.key == Data(item1Key))
+                #expect(getAttempt2?.value == Data("🍎".utf8))
+            }
+            #expect(
+                successes == numberOfNodes,
+                "\(numberOfNodes - successes)/\(numberOfNodes) Nodes were unable to retrieve the value"
+            )
+
+            //let beaconNodePeerCount = try beaconNode.peers.count().wait()
+            //print("BeaconNode::PeerCount == \(beaconNodePeerCount)")
+            //for i in (0..<numberOfNodes) {
+            //    let peerCount = try nodes[i].peers.count().wait()
+            //    print("Node[\(i)]::PeerCount == \(peerCount)")
+            //}
+
+            beaconNode.shutdown()
+            for node in nodes { node.shutdown() }
+
+            //sleep(1)
+
+            print("All Done!")
         }
 
-        try beaconNode.start()
-        for node in nodes { try node.start() }
+        var nextPort: Int = 10000
+        private func makeHost(
+            mode: KadDHT.Mode = .client,
+            options: KadDHT.NodeOptions = .default,
+            bootstrapPeers: [PeerInfo] = BootstrapPeerDiscovery.IPFSBootNodes,
+            autoHeartbeat: Bool = false,
+            usingGroup: Application.EventLoopGroupProvider = .singleton
+        ) throws -> Application {
+            let lib = try Application(.testing, peerID: PeerID(.Ed25519), eventLoopGroupProvider: usingGroup)
+            lib.logger.logLevel = .notice
+            lib.security.use(.noise)
+            lib.muxers.use(.yamux)
+            lib.dht.use(
+                .kadDHT(mode: mode, options: options, bootstrapPeers: bootstrapPeers, autoUpdate: autoHeartbeat)
+            )
+            lib.servers.use(.tcp(host: "127.0.0.1", port: self.nextPort))
 
-        for node in nodes {
-            try node.dht.kadDHT.heartbeat().wait()
+            self.nextPort += 1
+            return lib
         }
-
-        try beaconNode.dht.kadDHT.heartbeat().wait()
-
-        let item1Key = "/fruit/".bytes + Digest.sha256("apple".bytes)
-        let item1Record = DHT.Record.with {
-            $0.key = Data(item1Key)
-            $0.value = Data("🍎".utf8)
-        }
-
-        let storeAttempt1 = try nodes[0].dht.kadDHT.storeNew(item1Key, value: item1Record).wait()
-        #expect(storeAttempt1)
-
-        for node in nodes {
-            try node.dht.kadDHT.heartbeat().wait()
-        }
-
-        try beaconNode.dht.kadDHT.heartbeat().wait()
-
-        let storeAttempt2 = try nodes[0].dht.kadDHT.storeNew(item1Key, value: item1Record).wait()
-        #expect(storeAttempt2)
-
-        // Ensure the beacon node can retrieve the value
-        let getAttempt1 = try beaconNode.dht.kadDHT.getUsingLookupList(item1Key).wait()
-        #expect(getAttempt1 != nil)
-        #expect(getAttempt1?.key == Data(item1Key))
-        #expect(getAttempt1?.value == Data("🍎".utf8))
-
-        // Ensure the other nodes can retrieve the value
-        var successes = getAttempt1 == nil ? 0 : 1
-        for i in 1..<numberOfNodes {
-            let getAttempt2 = try nodes[i].dht.kadDHT.getUsingLookupList(item1Key).wait()
-            if getAttempt2 != nil { successes += 1 }
-            #expect(getAttempt2 != nil)
-            #expect(getAttempt2?.key == Data(item1Key))
-            #expect(getAttempt2?.value == Data("🍎".utf8))
-        }
-        #expect(
-            successes == numberOfNodes,
-            "\(numberOfNodes - successes)/\(numberOfNodes) Nodes were unable to retrieve the value"
-        )
-
-        //let beaconNodePeerCount = try beaconNode.peers.count().wait()
-        //print("BeaconNode::PeerCount == \(beaconNodePeerCount)")
-        //for i in (0..<numberOfNodes) {
-        //    let peerCount = try nodes[i].peers.count().wait()
-        //    print("Node[\(i)]::PeerCount == \(peerCount)")
-        //}
-
-        beaconNode.shutdown()
-        for node in nodes { node.shutdown() }
-
-        //sleep(1)
-
-        print("All Done!")
     }
 
-    var nextPort: Int = 10000
-    private func makeHost(
-        mode: KadDHT.Mode = .client,
-        options: KadDHT.NodeOptions = .default,
-        bootstrapPeers: [PeerInfo] = BootstrapPeerDiscovery.IPFSBootNodes,
-        autoHeartbeat: Bool = false,
-        usingGroup: Application.EventLoopGroupProvider = .singleton
-    ) throws -> Application {
-        let lib = try Application(.testing, peerID: PeerID(.Ed25519), eventLoopGroupProvider: usingGroup)
-        lib.logger.logLevel = .notice
-        lib.security.use(.noise)
-        lib.muxers.use(.yamux)
-        lib.dht.use(.kadDHT(mode: mode, options: options, bootstrapPeers: bootstrapPeers, autoUpdate: autoHeartbeat))
-        lib.servers.use(.tcp(host: "127.0.0.1", port: self.nextPort))
-
-        self.nextPort += 1
-        return lib
-    }
 }

--- a/Tests/LibP2PKadDHTTests/KadFramingTests.swift
+++ b/Tests/LibP2PKadDHTTests/KadFramingTests.swift
@@ -19,111 +19,115 @@ import Testing
 
 @testable import LibP2PKadDHT
 
-/// Proves the `/ipfs/kad/1.0.0` receive path reassembles messages
-/// correctly regardless of how the peer chunks its writes.
-///
-/// Canonical libp2p frames every kad message as `uvarint(len) + protobuf`.
-/// The route installs `VarintFrameDecoder` and `Query.decode` parses the
-/// already-stripped frame. Previously the route had no frame decoder and
-/// `Query.decode` asserted the whole frame arrived in a single read — which
-/// only held when the peer flushed one message per yamux frame (swift↔swift)
-/// and broke against peers that segment differently (e.g. rust-libp2p).
-///
-/// These tests feed the decoder adversarially-split input — every byte
-/// boundary, byte-by-byte dribble, and multiple messages in one buffer — and
-/// assert it always emits exactly the original frames, each of which
-/// `Query.decode` round-trips.
-@Suite("KadDHT wire framing")
-struct KadFramingTests {
+extension LibP2PKadDHTTests {
 
-    /// The on-the-wire bytes a sender produces: `uvarint(len) + protobuf`.
-    private func wireBytes(for query: KadDHT.Query) throws -> [UInt8] {
-        try query.encode()
-    }
+    /// Proves the `/ipfs/kad/1.0.0` receive path reassembles messages
+    /// correctly regardless of how the peer chunks its writes.
+    ///
+    /// Canonical libp2p frames every kad message as `uvarint(len) + protobuf`.
+    /// The route installs `VarintFrameDecoder` and `Query.decode` parses the
+    /// already-stripped frame. Previously the route had no frame decoder and
+    /// `Query.decode` asserted the whole frame arrived in a single read — which
+    /// only held when the peer flushed one message per yamux frame (swift↔swift)
+    /// and broke against peers that segment differently (e.g. rust-libp2p).
+    ///
+    /// These tests feed the decoder adversarially-split input — every byte
+    /// boundary, byte-by-byte dribble, and multiple messages in one buffer — and
+    /// assert it always emits exactly the original frames, each of which
+    /// `Query.decode` round-trips.
+    @Suite("KadDHT wire framing")
+    struct KadFramingTests {
 
-    /// Runs `bytes`, delivered as `chunks`, through a `VarintFrameDecoder`
-    /// (the exact handler the kad route installs) and returns the emitted,
-    /// length-prefix-stripped frames.
-    private func framesFrom(chunks: [[UInt8]]) throws -> [[UInt8]] {
-        let channel = EmbeddedChannel()
-        try channel.pipeline.addHandler(ByteToMessageHandler(VarintFrameDecoder())).wait()
-        for chunk in chunks where !chunk.isEmpty {
-            var buf = channel.allocator.buffer(capacity: chunk.count)
-            buf.writeBytes(chunk)
-            _ = try channel.writeInbound(buf)
+        /// The on-the-wire bytes a sender produces: `uvarint(len) + protobuf`.
+        private func wireBytes(for query: KadDHT.Query) throws -> [UInt8] {
+            try query.encode()
         }
-        var frames: [[UInt8]] = []
-        while let frame = try channel.readInbound(as: ByteBuffer.self) {
-            frames.append(Array(frame.readableBytesView))
-        }
-        _ = try channel.finish()
-        return frames
-    }
 
-    /// A key large enough that its length prefix is a *multi-byte* uvarint
-    /// (>= 128), so splitting inside the prefix also exercises the varint
-    /// continuation path — not just the prefix/body boundary.
-    private var largeKey: [UInt8] { Array(repeating: UInt8(ascii: "k"), count: 300) }
-
-    @Test("a single frame split at every byte boundary yields exactly one decodable Query")
-    func splitAtEveryBoundary() throws {
-        let key = largeKey
-        let wire = try wireBytes(for: .getValue(key: key))
-        #expect(wire.count > 129, "key should force a multi-byte length prefix")
-
-        for split in 0...wire.count {
-            let frames = try framesFrom(chunks: [Array(wire[0..<split]), Array(wire[split...])])
-            #expect(frames.count == 1, "split at offset \(split) should yield exactly one frame")
-            guard case .getValue(let decodedKey) = try KadDHT.Query.decode(frames[0]) else {
-                Issue.record("split \(split): expected a getValue query")
-                continue
+        /// Runs `bytes`, delivered as `chunks`, through a `VarintFrameDecoder`
+        /// (the exact handler the kad route installs) and returns the emitted,
+        /// length-prefix-stripped frames.
+        private func framesFrom(chunks: [[UInt8]]) throws -> [[UInt8]] {
+            let channel = EmbeddedChannel()
+            try channel.pipeline.addHandler(ByteToMessageHandler(VarintFrameDecoder())).wait()
+            for chunk in chunks where !chunk.isEmpty {
+                var buf = channel.allocator.buffer(capacity: chunk.count)
+                buf.writeBytes(chunk)
+                _ = try channel.writeInbound(buf)
             }
-            #expect(decodedKey == key, "split \(split): key survived reassembly")
+            var frames: [[UInt8]] = []
+            while let frame = try channel.readInbound(as: ByteBuffer.self) {
+                frames.append(Array(frame.readableBytesView))
+            }
+            _ = try channel.finish()
+            return frames
+        }
+
+        /// A key large enough that its length prefix is a *multi-byte* uvarint
+        /// (>= 128), so splitting inside the prefix also exercises the varint
+        /// continuation path — not just the prefix/body boundary.
+        private var largeKey: [UInt8] { Array(repeating: UInt8(ascii: "k"), count: 300) }
+
+        @Test("a single frame split at every byte boundary yields exactly one decodable Query")
+        func splitAtEveryBoundary() throws {
+            let key = largeKey
+            let wire = try wireBytes(for: .getValue(key: key))
+            #expect(wire.count > 129, "key should force a multi-byte length prefix")
+
+            for split in 0...wire.count {
+                let frames = try framesFrom(chunks: [Array(wire[0..<split]), Array(wire[split...])])
+                #expect(frames.count == 1, "split at offset \(split) should yield exactly one frame")
+                guard case .getValue(let decodedKey) = try KadDHT.Query.decode(frames[0]) else {
+                    Issue.record("split \(split): expected a getValue query")
+                    continue
+                }
+                #expect(decodedKey == key, "split \(split): key survived reassembly")
+            }
+        }
+
+        @Test("byte-by-byte dribble reassembles into one frame")
+        func byteByByteDribble() throws {
+            let key = largeKey
+            let wire = try wireBytes(for: .getValue(key: key))
+            let frames = try framesFrom(chunks: wire.map { [$0] })
+            #expect(frames.count == 1)
+            guard case .getValue(let decodedKey) = try KadDHT.Query.decode(frames[0]) else {
+                Issue.record("expected a getValue query")
+                return
+            }
+            #expect(decodedKey == key)
+        }
+
+        @Test("two concatenated messages in one read yield two frames")
+        func twoMessagesInOneBuffer() throws {
+            let k1 = Array("first-key".utf8)
+            let k2 = largeKey
+            let wire = try wireBytes(for: .getValue(key: k1)) + wireBytes(for: .getValue(key: k2))
+            let frames = try framesFrom(chunks: [wire])
+            #expect(frames.count == 2)
+            guard case .getValue(let a) = try KadDHT.Query.decode(frames[0]),
+                case .getValue(let b) = try KadDHT.Query.decode(frames[1])
+            else {
+                Issue.record("expected two getValue queries")
+                return
+            }
+            #expect(a == k1)
+            #expect(b == k2)
+        }
+
+        @Test("FIND_NODE accepts an arbitrary (non-PeerID) key")
+        func findNodeAcceptsArbitraryKey() throws {
+            // rust-libp2p bootstraps with raw 32-byte keys that are not
+            // multihash-shaped PeerIds. The decoder must accept them.
+            let randomKey = (0..<32).map { UInt8($0) }
+            let wire = try wireBytes(for: .findNode(key: randomKey))
+            let frames = try framesFrom(chunks: [wire])
+            #expect(frames.count == 1)
+            guard case .findNode(let decodedKey) = try KadDHT.Query.decode(frames[0]) else {
+                Issue.record("expected a findNode query")
+                return
+            }
+            #expect(decodedKey == randomKey)
         }
     }
 
-    @Test("byte-by-byte dribble reassembles into one frame")
-    func byteByByteDribble() throws {
-        let key = largeKey
-        let wire = try wireBytes(for: .getValue(key: key))
-        let frames = try framesFrom(chunks: wire.map { [$0] })
-        #expect(frames.count == 1)
-        guard case .getValue(let decodedKey) = try KadDHT.Query.decode(frames[0]) else {
-            Issue.record("expected a getValue query")
-            return
-        }
-        #expect(decodedKey == key)
-    }
-
-    @Test("two concatenated messages in one read yield two frames")
-    func twoMessagesInOneBuffer() throws {
-        let k1 = Array("first-key".utf8)
-        let k2 = largeKey
-        let wire = try wireBytes(for: .getValue(key: k1)) + wireBytes(for: .getValue(key: k2))
-        let frames = try framesFrom(chunks: [wire])
-        #expect(frames.count == 2)
-        guard case .getValue(let a) = try KadDHT.Query.decode(frames[0]),
-            case .getValue(let b) = try KadDHT.Query.decode(frames[1])
-        else {
-            Issue.record("expected two getValue queries")
-            return
-        }
-        #expect(a == k1)
-        #expect(b == k2)
-    }
-
-    @Test("FIND_NODE accepts an arbitrary (non-PeerID) key")
-    func findNodeAcceptsArbitraryKey() throws {
-        // rust-libp2p bootstraps with raw 32-byte keys that are not
-        // multihash-shaped PeerIds. The decoder must accept them.
-        let randomKey = (0..<32).map { UInt8($0) }
-        let wire = try wireBytes(for: .findNode(key: randomKey))
-        let frames = try framesFrom(chunks: [wire])
-        #expect(frames.count == 1)
-        guard case .findNode(let decodedKey) = try KadDHT.Query.decode(frames[0]) else {
-            Issue.record("expected a findNode query")
-            return
-        }
-        #expect(decodedKey == randomKey)
-    }
 }

--- a/Tests/LibP2PKadDHTTests/LibP2PKadDHTTests.swift
+++ b/Tests/LibP2PKadDHTTests/LibP2PKadDHTTests.swift
@@ -23,7 +23,7 @@ import Testing
 @testable import LibP2PKadDHT
 
 @Suite("Libp2p KadDHT Tests", .serialized)
-final class LibP2PKadDHTTests {
+struct LibP2PKadDHTTests {
 
     @Test func testEventLoopArray() throws {
         let group = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)

--- a/Tests/LibP2PKadDHTTests/LookupListTests.swift
+++ b/Tests/LibP2PKadDHTTests/LookupListTests.swift
@@ -19,87 +19,91 @@ import Testing
 
 @testable import LibP2PKadDHT
 
-@Suite("LookupList Tests")
-struct LookupListTests {
+extension LibP2PKadDHTTests {
 
-    /// Lookup Lists
-    @Test func testLookupListInit() throws {
-        let list = try LookupList(id: PeerID(), capacity: 20)
+    @Suite("LookupList Tests", .serialized)
+    struct LookupListTests {
 
-        #expect(list.capacity == 20)
-        #expect(list.all().count == 0)
-    }
+        /// Lookup Lists
+        @Test func testLookupListInit() throws {
+            let list = try LookupList(id: PeerID(), capacity: 20)
 
-    @Test func testLookupListInsert() throws {
-        let ourID = try PeerID(.Ed25519)
-        let list = LookupList(id: ourID, capacity: 20)
-        let peerCount = 100
-        let randomPeers = try (0..<peerCount).map { _ in try generateRandomPeerInfo() }
-
-        for i in 0..<10 {
-            #expect(list.insert(randomPeers[i]))
+            #expect(list.capacity == 20)
+            #expect(list.all().count == 0)
         }
 
-        /// All ten addresses should've been inserted into the list due to excess capacity
-        #expect(list.all().count == 10)
+        @Test func testLookupListInsert() throws {
+            let ourID = try PeerID(.Ed25519)
+            let list = LookupList(id: ourID, capacity: 20)
+            let peerCount = 100
+            let randomPeers = try (0..<peerCount).map { _ in try generateRandomPeerInfo() }
 
-        for i in 10..<peerCount {
-            list.insert(randomPeers[i])
+            for i in 0..<10 {
+                #expect(list.insert(randomPeers[i]))
+            }
+
+            /// All ten addresses should've been inserted into the list due to excess capacity
+            #expect(list.all().count == 10)
+
+            for i in 10..<peerCount {
+                list.insert(randomPeers[i])
+            }
+
+            /// The list should only contain the max number of peers (capcaity == 20)
+            #expect(list.all().count == 20)
+
+            /// And they should be the closest peers to ourselves
+            let contacts = list.all()
+            for i in 0..<contacts.count - 1 {
+                #expect(ourID.compareDistancesFromSelf(to: contacts[i].peer, and: contacts[i + 1].peer) == .firstKey)
+            }
+
+            print(list.dumpMetrics())
         }
 
-        /// The list should only contain the max number of peers (capcaity == 20)
-        #expect(list.all().count == 20)
+        @Test func testLookupListNext() throws {
+            let list = LookupList(id: KadDHT.Key.Zero, capacity: 20)
 
-        /// And they should be the closest peers to ourselves
-        let contacts = list.all()
-        for i in 0..<contacts.count - 1 {
-            #expect(ourID.compareDistancesFromSelf(to: contacts[i].peer, and: contacts[i + 1].peer) == .firstKey)
+            /// Insert a few keys
+            let randomPeers = try (0..<20).map { _ in try generateRandomPeerInfo() }
+            let sorted = randomPeers.map { $0.peer }.sortedAbsolutely()
+
+            /// Insert the peers in random order
+            for peer in randomPeers {
+                #expect(list.insert(peer))
+            }
+
+            /// Ask for the first peer using .next()
+            /// This should return the closest peer to our target id which is 0 and therefore the first index in our `sorted` array
+            let next = list.next()
+            #expect(next!.peer == sorted[0])
+
+            /// If we try and insert that same peer again, we return true to indicate that the peer is in the list, but we shouldn't be handed that peer twice when calling .next()
+            list.insert(next!)
+
+            /// Calling next repeatedly should return results in sorted order until each has been processed
+            #expect(list.next()!.peer == sorted[1])
+            #expect(list.next()!.peer == sorted[2])
+            #expect(list.next()!.peer == sorted[3])
+            #expect(list.next()!.peer == sorted[4])
+            #expect(list.next()!.peer == sorted[5])
+            #expect(list.next()!.peer == sorted[6])
+            #expect(list.next()!.peer == sorted[7])
+            #expect(list.next()!.peer == sorted[8])
+            #expect(list.next()!.peer == sorted[9])
+            #expect(list.next()!.peer == sorted[10])
+            #expect(list.next()!.peer == sorted[11])
+            #expect(list.next()!.peer == sorted[12])
+            #expect(list.next()!.peer == sorted[13])
+            #expect(list.next()!.peer == sorted[14])
+            #expect(list.next()!.peer == sorted[15])
+            #expect(list.next()!.peer == sorted[16])
+            #expect(list.next()!.peer == sorted[17])
+            #expect(list.next()!.peer == sorted[18])
+            #expect(list.next()!.peer == sorted[19])
+            #expect(list.next() == nil)
         }
 
-        print(list.dumpMetrics())
-    }
-
-    @Test func testLookupListNext() throws {
-        let list = LookupList(id: KadDHT.Key.Zero, capacity: 20)
-
-        /// Insert a few keys
-        let randomPeers = try (0..<20).map { _ in try generateRandomPeerInfo() }
-        let sorted = randomPeers.map { $0.peer }.sortedAbsolutely()
-
-        /// Insert the peers in random order
-        for peer in randomPeers {
-            #expect(list.insert(peer))
-        }
-
-        /// Ask for the first peer using .next()
-        /// This should return the closest peer to our target id which is 0 and therefore the first index in our `sorted` array
-        let next = list.next()
-        #expect(next!.peer == sorted[0])
-
-        /// If we try and insert that same peer again, we return true to indicate that the peer is in the list, but we shouldn't be handed that peer twice when calling .next()
-        list.insert(next!)
-
-        /// Calling next repeatedly should return results in sorted order until each has been processed
-        #expect(list.next()!.peer == sorted[1])
-        #expect(list.next()!.peer == sorted[2])
-        #expect(list.next()!.peer == sorted[3])
-        #expect(list.next()!.peer == sorted[4])
-        #expect(list.next()!.peer == sorted[5])
-        #expect(list.next()!.peer == sorted[6])
-        #expect(list.next()!.peer == sorted[7])
-        #expect(list.next()!.peer == sorted[8])
-        #expect(list.next()!.peer == sorted[9])
-        #expect(list.next()!.peer == sorted[10])
-        #expect(list.next()!.peer == sorted[11])
-        #expect(list.next()!.peer == sorted[12])
-        #expect(list.next()!.peer == sorted[13])
-        #expect(list.next()!.peer == sorted[14])
-        #expect(list.next()!.peer == sorted[15])
-        #expect(list.next()!.peer == sorted[16])
-        #expect(list.next()!.peer == sorted[17])
-        #expect(list.next()!.peer == sorted[18])
-        #expect(list.next()!.peer == sorted[19])
-        #expect(list.next() == nil)
     }
 
 }

--- a/Tests/LibP2PKadDHTTests/MockNetworkTests.swift
+++ b/Tests/LibP2PKadDHTTests/MockNetworkTests.swift
@@ -12,9 +12,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+import CID
 import CryptoSwift
 import LibP2P
 import LibP2PCrypto
+import Multihash
 import Testing
 
 @testable import LibP2PKadDHT
@@ -138,21 +140,23 @@ struct MockNetworkTests {
         }
 
         /// Test Query.findNode and Response.nodeSearch
-        let query = KadDHT.Query.findNode(id: testAddresses.first!.peer)
+        let target = testAddresses.first!.peer
+        let query = KadDHT.Query.findNode(key: target.id)
         let encodedQuery = try query.encode()
 
         /// Send it over the wire...
         let decodedQuery = try KadDHT.Query.decode(encodedQuery)
         print("Recovered Query: \(decodedQuery)")
 
-        guard case .findNode(let peer) = decodedQuery else {
+        guard case .findNode(let recoveredKey) = decodedQuery else {
             Issue.record("Query is not a findNode")
             return
         }
 
-        let response = try KadDHT.Response.findNode(
-            closerPeers: testAddresses.filter({ $0.peer != peer }).map { try DHT.Message.Peer($0) }
-        )
+        #expect(recoveredKey == target.id)
+
+        let closer = try testAddresses.filter({ $0.peer != target }).map { try DHT.Message.Peer($0) }
+        let response = KadDHT.Response.findNode(closerPeers: closer)
         let encodedResponse = try response.encode()
 
         /// Send the response back over the wire...
@@ -166,7 +170,34 @@ struct MockNetworkTests {
         print(closerPeers)
 
         #expect(closerPeers.count == testAddresses.count - 1)
-        #expect(try closerPeers.contains(where: { try $0.toPeerInfo().peer == peer }) == false)
+        let recoveredPeers = try closerPeers.map { try $0.toPeerInfo().peer }
+        #expect(recoveredPeers.contains(target) == false)
+    }
+
+    /// A FIND_NODE whose key is a *record* key rather than a PeerID must still round-trip.
+    ///
+    /// This is what `PUT_VALUE`/`GET_VALUE` lookups walk towards, and go-libp2p sends those bytes
+    /// verbatim. We used to require the key to parse as a `PeerID`, which rejected them outright.
+    @Test func testDHTFauxNetworkQuery_FindNode_RecordKeyTarget() throws {
+        let pid = try PeerID(.Ed25519)
+        let recordKey = "/pk/".bytes + pid.id
+
+        /// Sanity check: this key is deliberately NOT a valid PeerID.
+        #expect(throws: (any Error).self) { try PeerID(fromBytesID: recordKey) }
+
+        let encoded = try KadDHT.Query.findNode(key: recordKey).encode()
+        let decoded = try KadDHT.Query.decode(encoded)
+
+        guard case .findNode(let recovered) = decoded else {
+            Issue.record("Query is not a findNode")
+            return
+        }
+        #expect(recovered == recordKey)
+    }
+
+    /// An empty FIND_NODE key is still rejected.
+    @Test func testDHTFauxNetworkQuery_FindNode_RejectsEmptyKey() throws {
+        #expect(throws: (any Error).self) { try KadDHT.Query.findNode(key: []).encode() }
     }
 
     @Test func testDHTFauxNetworkQuery_GetValue_NoValue() throws {
@@ -287,6 +318,107 @@ struct MockNetworkTests {
             let peerID = try PeerID(fromBytesID: peer.id.byteArray)
             let addresses = try peer.addrs.map { try Multiaddr($0) }
             print(PeerInfo(peer: peerID, addresses: addresses))
+        }
+    }
+
+    // MARK: - Provider records
+
+    /// Provider keys are multihashes, not CIDs. We must accept any multihash code, and reject only on
+    /// go's length bound (1...80).
+    @Test func testDHTFauxNetworkQuery_GetProviders_AcceptsAnyMultihash() throws {
+        /// A sha2-256 multihash (this one happens to also be a valid CIDv0)...
+        let sha256Multihash = try Multihash(raw: "provider test", hashedWith: .sha2_256).value
+
+        /// ...and a blake3-256 multihash, hand-assembled as `varint(code) + varint(length) + digest`.
+        /// We build the bytes directly because what matters here is that we accept an arbitrary
+        /// multihash *code*, not that we can compute that hash.
+        let blake3Multihash: [UInt8] = [0x1e, 0x20] + (try LibP2PCrypto.randomBytes(length: 32))
+
+        /// The point of the fix: this key is NOT parseable as a CID, so the old
+        /// `guard let CID = try? CID(key)` would have rejected it outright.
+        #expect(throws: (any Error).self) { try CID(blake3Multihash) }
+        #expect(throws: Never.self) { try CID(sha256Multihash) }
+
+        for key in [sha256Multihash, blake3Multihash] {
+            let decoded = try KadDHT.Query.decode(try KadDHT.Query.getProviders(key: key).encode())
+            guard case .getProviders(let recovered) = decoded else {
+                Issue.record("Query is not a getProviders for key \(key.toHexString())")
+                return
+            }
+            #expect(recovered == key)
+        }
+    }
+
+    @Test func testDHTFauxNetworkQuery_GetProviders_RejectsOutOfBoundsKeys() throws {
+        #expect(throws: (any Error).self) { try KadDHT.Query.getProviders(key: []).encode() }
+        #expect(throws: (any Error).self) {
+            try KadDHT.Query.getProviders(key: [UInt8](repeating: 0xAB, count: 81)).encode()
+        }
+        /// Exactly at the bound is fine
+        #expect(throws: Never.self) {
+            try KadDHT.Query.getProviders(key: [UInt8](repeating: 0xAB, count: 80)).encode()
+        }
+    }
+
+    /// A GET_PROVIDERS response must be able to carry providers *and* closer peers at the same time.
+    @Test func testDHTFauxNetworkResponse_GetProviders_CarriesProvidersAndCloserPeers() throws {
+        let key = try Multihash(raw: "provider test", hashedWith: .sha2_256).value
+        let providers = try (0..<2).map { _ in try DHT.Message.Peer(try generateRandomPeerInfo()) }
+        let closer = try (0..<3).map { _ in try DHT.Message.Peer(try generateRandomPeerInfo()) }
+
+        let decoded = try KadDHT.Response.decode(
+            try KadDHT.Response.getProviders(cid: key, providerPeers: providers, closerPeers: closer).encode()
+        )
+
+        guard case .getProviders(let recoveredKey, let recoveredProviders, let recoveredCloser) = decoded else {
+            Issue.record("Response is not a getProviders")
+            return
+        }
+
+        #expect(recoveredKey == key)
+        #expect(recoveredProviders.count == 2)
+        #expect(recoveredCloser.count == 3)
+    }
+
+    /// ADD_PROVIDER carries the provider's own PeerInfo in `providerPeers` — that's where a receiving node
+    /// learns the provider's dialable addresses from.
+    @Test func testDHTFauxNetworkQuery_AddProvider_RoundTripsProviderPeers() throws {
+        let key = try Multihash(raw: "provider test", hashedWith: .sha2_256).value
+        let me = try generateRandomPeerInfo()
+
+        let decoded = try KadDHT.Query.decode(
+            try KadDHT.Query.addProvider(key: key, providerPeers: [try DHT.Message.Peer(me)]).encode()
+        )
+
+        guard case .addProvider(let recoveredKey, let recoveredProviders) = decoded else {
+            Issue.record("Query is not an addProvider")
+            return
+        }
+
+        #expect(recoveredKey == key)
+        #expect(recoveredProviders.count == 1)
+        let recoveredInfo = try recoveredProviders[0].toPeerInfo()
+        #expect(recoveredInfo.peer == me.peer)
+        #expect(recoveredInfo.addresses == me.addresses)
+    }
+
+    // MARK: - PING
+
+    /// Decoding a PING response used to read 8 bytes out of `dht.key` regardless of how many the peer
+    /// actually sent, which is an out-of-bounds read driven by remote input.
+    @Test func testDHTFauxNetworkResponse_Ping_ToleratesArbitraryKeyLengths() throws {
+        for length in [0, 1, 3, 7, 8, 9] {
+            var message = DHT.Message()
+            message.type = .ping
+            if length > 0 { message.key = Data([UInt8](repeating: 0xFF, count: length)) }
+
+            let payload = try message.serializedData()
+            let framed = putUVarInt(UInt64(payload.count)) + [UInt8](payload)
+
+            guard case .ping = try KadDHT.Response.decode(framed) else {
+                Issue.record("Response is not a ping for a \(length) byte key")
+                return
+            }
         }
     }
 }

--- a/Tests/LibP2PKadDHTTests/MockNetworkTests.swift
+++ b/Tests/LibP2PKadDHTTests/MockNetworkTests.swift
@@ -183,7 +183,7 @@ struct MockNetworkTests {
         let pid = try PeerID(.Ed25519)
         let recordKey = "/pk/".bytes + pid.id
 
-        /// Sanity check: this key is deliberately NOT a valid PeerID.
+        /// Ensure that this key is NOT a valid PeerID.
         #expect(throws: (any Error).self) { try PeerID(fromBytesID: recordKey) }
 
         let encoded = try KadDHT.Query.findNode(key: recordKey).encode()

--- a/Tests/LibP2PKadDHTTests/MockNetworkTests.swift
+++ b/Tests/LibP2PKadDHTTests/MockNetworkTests.swift
@@ -21,404 +21,407 @@ import Testing
 
 @testable import LibP2PKadDHT
 
-@Suite("Mock Network Tests")
-struct MockNetworkTests {
+extension LibP2PKadDHTTests {
 
-    @Test func testDHTFauxNetworkQuery_Ping() throws {
-        /// Test Query.ping and Response.ping
-        let query = KadDHT.Query.ping
-        let encodedQuery = try query.encode()
+    @Suite("Mock Network Tests")
+    struct MockNetworkTests {
 
-        /// Send it over the wire...
+        @Test func testDHTFauxNetworkQuery_Ping() throws {
+            /// Test Query.ping and Response.ping
+            let query = KadDHT.Query.ping
+            let encodedQuery = try query.encode()
 
-        let decodedQuery = try decodeQueryFrame(encodedQuery)
-        print("Recovered Query: \(decodedQuery)")
+            /// Send it over the wire...
 
-        guard case .ping = decodedQuery else {
-            Issue.record("Query is not a ping")
-            return
-        }
+            let decodedQuery = try decodeQueryFrame(encodedQuery)
+            print("Recovered Query: \(decodedQuery)")
 
-        let response = KadDHT.Response.ping
-        let encodedResponse = try response.encode()
-
-        /// Send the response back over the wire...
-
-        let decodedResponse = try KadDHT.Response.decode(encodedResponse)
-
-        guard case .ping = decodedResponse else {
-            Issue.record("Response is not a ping")
-            return
-        }
-    }
-
-    @Test func testDHTFauxNetworkQuery_Store_Success() throws {
-        /// Test Query.store and Response.stored
-        let recordToStore = DHT.Record.with({ rec in
-            rec.key = Data("test".utf8)
-            rec.value = Data("Kademlia DHT".utf8)
-        })
-        let query = KadDHT.Query.putValue(key: "test".bytes, record: recordToStore)
-        let encodedQuery = try query.encode()
-
-        /// Send it over the wire...
-
-        let decodedQuery = try decodeQueryFrame(encodedQuery)
-        print("Recovered Query: \(decodedQuery)")
-
-        guard case .putValue(let qKey, let qRecord) = decodedQuery else {
-            Issue.record("Query is not a putValue")
-            return
-        }
-
-        /// Assume we can store the value
-        print("Storing Value: '\(qRecord)' for Key: '\(qKey)'")
-        let response = KadDHT.Response.putValue(key: qKey, record: qRecord)
-        let encodedResponse = try response.encode()
-
-        /// Send the response back over the wire...
-
-        let decodedResponse = try KadDHT.Response.decode(encodedResponse)
-
-        guard case .putValue(let key, let record) = decodedResponse else {
-            Issue.record("Response is not a putValue")
-            return
-        }
-
-        #expect(key == recordToStore.key.byteArray)
-        #expect(record == recordToStore)
-    }
-
-    @Test func testDHTFauxNetworkQuery_Store_Failure() throws {
-        /// Test Query.store and Response.stored
-        let recordToStore = DHT.Record.with({ rec in
-            rec.key = Data("test".utf8)
-            rec.value = Data("hello!".utf8)
-        })
-        let query = KadDHT.Query.putValue(key: "test".bytes, record: recordToStore)
-        let encodedQuery = try query.encode()
-
-        /// Send it over the wire...
-
-        let decodedQuery = try decodeQueryFrame(encodedQuery)
-        print("Recovered Query: \(decodedQuery)")
-
-        guard case .putValue(let key, let value) = decodedQuery else {
-            Issue.record("Query is not a putValue")
-            return
-        }
-
-        /// Assume we can't store the value for some reason
-        print("Failed to store Value: '\(value)' for Key: '\(key)'")
-        let response = KadDHT.Response.putValue(key: "test".bytes, record: nil)
-        let encodedResponse = try response.encode()
-
-        /// Send the response back over the wire...
-
-        let decodedResponse = try KadDHT.Response.decode(encodedResponse)
-
-        guard case .putValue(let key, let value) = decodedResponse else {
-            Issue.record("Response is not a putValue")
-            return
-        }
-
-        #expect(key == "test".bytes)
-        #expect(value == nil)
-    }
-
-    @Test func testDHTFauxNetworkQuery_FindNode() throws {
-        let testAddresses = try (0..<10).map { i -> PeerInfo in
-            let pid = try PeerID(.Ed25519)
-            return try PeerInfo(
-                peer: pid,
-                addresses: [Multiaddr("/ip4/127.0.0.1/tcp/\(1000 + i)/p2p/\(pid.b58String)")]
-            )
-        }
-
-        for peerInfo in testAddresses {
-            #expect(throws: Never.self) { try peerInfo.addresses.first?.getPeerID() }
-        }
-
-        /// Test Query.findNode and Response.nodeSearch
-        let targetPeer = testAddresses.first!.peer
-        let query = KadDHT.Query.findNode(key: targetPeer.id)
-        let encodedQuery = try query.encode()
-
-        /// Send it over the wire... (`decodeQueryFrame` unframes first, mirroring the receive path)
-        let decodedQuery = try decodeQueryFrame(encodedQuery)
-        print("Recovered Query: \(decodedQuery)")
-
-        guard case .findNode(let key) = decodedQuery else {
-            Issue.record("Query is not a findNode")
-            return
-        }
-        #expect(key == targetPeer.id)
-
-        let closer = try testAddresses.filter({ $0.peer != targetPeer }).map { try DHT.Message.Peer($0) }
-        let response = KadDHT.Response.findNode(closerPeers: closer)
-        let encodedResponse = try response.encode()
-
-        /// Send the response back over the wire...
-        let decodedResponse = try KadDHT.Response.decode(encodedResponse)
-
-        guard case .findNode(let closerPeers) = decodedResponse else {
-            Issue.record("Response is not a findNode")
-            return
-        }
-
-        print(closerPeers)
-
-        #expect(closerPeers.count == testAddresses.count - 1)
-        // Broken out of the `#expect` macro: the inline `try ... contains(where:) == false` form tripped a
-        // Swift type-checker timeout in this toolchain.
-        let recoveredPeers = try closerPeers.map { try $0.toPeerInfo().peer }
-        #expect(recoveredPeers.contains(targetPeer) == false)
-    }
-
-    /// A FIND_NODE whose key is a *record* key rather than a PeerID must still round-trip.
-    ///
-    /// This is what `PUT_VALUE`/`GET_VALUE` lookups walk towards, and go-libp2p sends those bytes
-    /// verbatim. We used to require the key to parse as a `PeerID`, which rejected them outright.
-    @Test func testDHTFauxNetworkQuery_FindNode_RecordKeyTarget() throws {
-        let pid = try PeerID(.Ed25519)
-        let recordKey = "/pk/".bytes + pid.id
-
-        /// Ensure that this key is NOT a valid PeerID.
-        #expect(throws: (any Error).self) { try PeerID(fromBytesID: recordKey) }
-
-        let encoded = try KadDHT.Query.findNode(key: recordKey).encode()
-        let decoded = try decodeQueryFrame(encoded)
-
-        guard case .findNode(let recovered) = decoded else {
-            Issue.record("Query is not a findNode")
-            return
-        }
-        #expect(recovered == recordKey)
-    }
-
-    /// An empty FIND_NODE key is still rejected.
-    @Test func testDHTFauxNetworkQuery_FindNode_RejectsEmptyKey() throws {
-        #expect(throws: (any Error).self) { try KadDHT.Query.findNode(key: []).encode() }
-    }
-
-    @Test func testDHTFauxNetworkQuery_GetValue_NoValue() throws {
-
-        /// Test Query.findValue and Response.keySearch
-        let query = KadDHT.Query.getValue(key: "test".bytes)
-        let encodedQuery = try query.encode()
-
-        /// Send it over the wire...
-
-        let decodedQuery = try decodeQueryFrame(encodedQuery)
-        print("Recovered Query: \(decodedQuery)")
-
-        guard case .getValue(let key) = decodedQuery else {
-            Issue.record("Query is not a getValue")
-            return
-        }
-
-        print("Key: \(key)")
-        #expect(key == "test".bytes)
-        /// Assume we don't have the key their looking for, so return a set of peers that are closer...
-        let testAddresses = try (0..<3).map {
-            let pid = try PeerID()
-            return try PeerInfo(
-                peer: pid,
-                addresses: [Multiaddr("/ip4/127.0.0.1/tcp/\(1000 + $0)/p2p/\(pid.b58String)")]
-            )
-        }
-
-        let response = try KadDHT.Response.getValue(
-            key: "test".bytes,
-            record: nil,
-            closerPeers: testAddresses.map { try DHT.Message.Peer($0) }
-        )
-        let encodedResponse = try response.encode()
-
-        /// Send the response back over the wire...
-
-        let decodedResponse = try KadDHT.Response.decode(encodedResponse)
-
-        guard case .getValue(let key, let record, let closerPeers) = decodedResponse else {
-            Issue.record("Response is not a getValue")
-            return
-        }
-
-        #expect(key == "test".bytes)
-        #expect(record == nil)
-        #expect(closerPeers.count == testAddresses.count)
-    }
-
-    @Test func testDHTFauxNetworkQuery_FindValue_FoundValue() throws {
-
-        /// Test Query.findValue and Response.keySearch
-        let query = KadDHT.Query.getValue(key: "test".bytes)
-        let encodedQuery = try query.encode()
-
-        /// Send it over the wire...
-
-        let decodedQuery = try decodeQueryFrame(encodedQuery)
-        print("Recovered Query: \(decodedQuery)")
-
-        guard case .getValue(let key) = decodedQuery else {
-            Issue.record("Query is not a getValue")
-            return
-        }
-
-        print("Key: \(key)")
-        #expect(key == "test".bytes)
-        /// Assume we have the key they're looking for
-        let value = DHT.Record.with({ rec in
-            rec.key = Data("test".utf8)
-            rec.value = Data("Kademlia DHT".utf8)
-        })
-
-        let response = KadDHT.Response.getValue(key: "test".bytes, record: value, closerPeers: [])
-        let encodedResponse = try response.encode()
-
-        /// Send the response back over the wire...
-
-        let decodedResponse = try KadDHT.Response.decode(encodedResponse)
-
-        guard case .getValue(let key, let record, let closerPeers) = decodedResponse else {
-            Issue.record("Response is not a getValue")
-            return
-        }
-
-        #expect(key == "test".bytes)
-        #expect(record != nil)
-        #expect(record?.key == Data("test".utf8))
-        #expect(record?.value == Data("Kademlia DHT".utf8))
-        #expect(closerPeers.count == 0)
-    }
-
-    // An example of a large response (>4kb) that gets chunked via our inbound stream window buffer.
-    // Make sure we can decode the message in it's entirety
-    @Test func testDecodeDHTMessage() throws {
-        let dhtMessage1of2 = Array(
-            hex:
-                "f637080442f6020a2600240801122064d6be62f0d67bf0a0a1d232d24badf66219c6ad14bb865b177b8e54a287a6071217290000000000000000000000000000000191020fa1cd03120b04c2f2399991020fa1cd031257047f00000191020fa1cd03d103d2032212200c0599ed33aa478dff2c0b7be3e40fb9f16c4ae2df843e772eea26ae1fd15db5d203221220faf5a659fd020440845c8a58c4ec099d7e03d54a7896bc45a3a5922e54722a3b1217290000000000000000000000000000000191020fa1cc03120804c2f23999060fa1120b047f00000191020fa1cc03120b04c2f2399991020fa1cc03120b047f00000191020fa1cd031263290000000000000000000000000000000191020fa1cd03d103d2032212200c0599ed33aa478dff2c0b7be3e40fb9f16c4ae2df843e772eea26ae1fd15db5d203221220faf5a659fd020440845c8a58c4ec099d7e03d54a7896bc45a3a5922e54722a3b12142900000000000000000000000000000001060fa11208047f000001060fa142f6020a26002408011220d0f66e25d1d87f42164273ad3f509776c989519c282fb7072d6e1b8dde2e8354120b047f00000191020fa1cd031257047f00000191020fa1cd03d103d2032212201462f5f8561d1a5b316278bc8b04e0c275b480f47563e038dc00809b0bdc23cfd20322122060a54b3a3fd85dcc5f4c5f4e2f7c337380086ea019f0aab2c99ed1ac3f0a93e712080468ee984d060fa1120b047f00000191020fa1cc03120b0468ee984d91020fa1cd03120b0468ee984d91020fa1cc031263290000000000000000000000000000000191020fa1cd03d103d2032212201462f5f8561d1a5b316278bc8b04e0c275b480f47563e038dc00809b0bdc23cfd20322122060a54b3a3fd85dcc5f4c5f4e2f7c337380086ea019f0aab2c99ed1ac3f0a93e71208047f000001060fa11217290000000000000000000000000000000191020fa1cd0312142900000000000000000000000000000001060fa11217290000000000000000000000000000000191020fa1cc0342a0050a260024080112208c65b9d3dfb7fba42c9a8e08835795a96e472a4de92faa31ef3c79da53d15888120b04ac1a065591020fa1cd031263290000000000000000000000000000000191020fa1cd03d103d203221220d9e268835631bd78774dd1a4ddcca806bd4a533a6cbc591826a92b66cc49606ad203221220e07f60f86b172ccd5d19c889da586a4339b078049162e7ecd01db371dc3bd1301257047f00000191020fa1cd03d103d203221220d9e268835631bd78774dd1a4ddcca806bd4a533a6cbc591826a92b66cc49606ad203221220e07f60f86b172ccd5d19c889da586a4339b078049162e7ecd01db371dc3bd1301217290000000000000000000000000000000191020fa1cd031217292406da1401b44d00a63d4d0362f1c84491020fa1cd03120b047f00000191020fa1cd0312080412b5b15e060fa1120b0412b5b15e91020fa1cc03120b0412b5b15e91020fa1cd031214292406da1401b44d00a63d4d0362f1c844060fa112142900000000000000000000000000000001060fa11208047f000001060fa11217292406da1401b44d00a63d4d0362f1c84491020fa1cc031217290000000000000000000000000000000191020fa1cc03125704ac1a065591020fa1cd03d103d203221220d9e268835631bd78774dd1a4ddcca806bd4a533a6cbc591826a92b66cc49606ad203221220e07f60f86b172ccd5d19c889da586a4339b078049162e7ecd01db371dc3bd130120804ac1a0655060fa1120b047f00000191020fa1cc03120b04ac1a065591020fa1cc031263292406da1401b44d00a63d4d0362f1c84491020fa1cd03d103d203221220d9e268835631bd78774dd1a4ddcca806bd4a533a6cbc591826a92b66cc49606ad203221220e07f60f86b172ccd5d19c889da586a4339b078049162e7ecd01db371dc3bd13042cf030a26002408011220575e3ace49bc995ac5b2eb5c8c297e834d1e28cdb437fa64a5e601c815c850bd120b048fc6608a91020fa1cc031257048fc6608a91020fa1cd03d103d20322122016e32acbeeb22dde4801df0966a1948d35593ccbcf13756d421af5334ab2840fd203221220cf569c33d875d0d45e2c2a74e2cd224dd5668440494e523c50083fbe90f991d91208047f000001060fa11217290000000000000000000000000000000191020fa1cd031257047f00000191020fa1cd03d103d20322122016e32acbeeb22dde4801df0966a1948d35593ccbcf13756d421af5334ab2840fd203221220cf569c33d875d0d45e2c2a74e2cd224dd5668440494e523c50083fbe90f991d91217290000000000000000000000000000000191020fa1cc031263290000000000000000000000000000000191020fa1cd03d103d20322122016e32acbeeb22dde4801df0966a1948d35593ccbcf13756d421af5334ab2840fd203221220cf569c33d875d0d45e2c2a74e2cd224dd5668440494e523c50083fbe90f991d9120b047f00000191020fa1cd0312142900000000000000000000000000000001060fa1120b047f00000191020fa1cc03120b048fc6608a91020fa1cd031208048fc6608a060fa142f6020a26002408011220228fd5775eec3088959e751d695a74bdacdc2b7dc9d31edebe9413879955028e120b04425e739f91020fa1cd031257047f00000191020fa1cd03d103d203221220ae3bf8e89b681a413c18ab5a1cf44792a734924f0bc70754690af458dd4cb7a5d203221220ef3f5909fb3ec4cf2036eb29bd00e5058389a08c8c14fa4248e72b31714ad22a1217290000000000000000000000000000000191020fa1cc0312142900000000000000000000000000000001060fa1120b04425e739f91020fa1cc03120b047f00000191020fa1cc031217290000000000000000000000000000000191020fa1cd03120804425e739f060fa1120b047f00000191020fa1cd031208047f000001060fa11263290000000000000000000000000000000191020fa1cd03d103d203221220ae3bf8e89b681a413c18ab5a1cf44792a734924f0bc70754690af458dd4cb7a5d203221220ef3f5909fb3ec4cf2036eb29bd00e5058389a08c8c14fa4248e72b31714ad22a42560a260024080112207dce2cdc07849bd25c2e1591e26cbc7e6208ec0ca133867a5b530d9370c3bd541208047f000001060fa1120b047f00000191020fa1cc03120b04339e3d5b91020fa1cc03120804339e3d5b060fa14283030a260024080112201b998427c1492b3453a77ec6349e1464bc2acce02d5d5c68b413dc39a9627633120b045ee7cd1491020fa1cd03120b045ee7cd1491020fa1cc03120b047f00000191020fa1cc031257047f00000191020fa1cd03d103d20322122080a8de3a1493c63aaafef7e4e03db946cd77ca0daaeaba4de3dc4ce56a7325a8d203221220de2326be8c3437c8ea378cc1759df0571bbd30842eacf74b2a42d1919a6a31bd1263290000000000000000000000000000000191020fa1cd03d103d20322122080a8de3a1493c63aaafef7e4e03db946cd77ca0daaeaba4de3dc4ce56a7325a8d203221220de2326be8c3437c8ea378cc1759df0571bbd30842eacf74b2a42d1919a6a31bd1217290000000000000000000000000000000191020fa1cc03120b047f00000191020fa1cd03120b045ee7cd14910206fecd031208045ee7cd14060fa11208047f000001060fa11217290000000000000000000000000000000191020fa1cd0312142900000000000000000000000000000001060fa142f6020a260024080112209afa2952a052536c477605db4f0e0ef6f2e76ea7fd867a7c1b151d517801cd5e1217290000000000000000000000000000000191020fa1cc03120b048f6ea85891020fa1cc031208048f6ea858060fa1120b048f6ea85891020fa1cd03120b047f00000191020fa1cc03120b047f00000191020fa1cd0312142900000000000000000000000000000001060fa11257047f00000191020fa1cd03d103d2032212206e38c8a586b513fbb58885bb0db90f8568a4b10030a3feb443403751efe78bf2d2032212208d3a9aab747a1bb051a3b1ada166ab8ab1720f9148ccf2bfe891227ffb4d9bc01208047f000001060fa11217290000000000000000000000000000000191020fa1cd031263290000000000000000000000000000000191020fa1cd03d103d2032212206e38c8a586b513fbb58885bb0db90f8568a4b10030a3feb443403751efe78bf2d2032212208d3a9aab747a1bb051a3b1ada166ab8ab1720f9148ccf2bfe891227ffb4d9bc042f6020a26002408011220754ea0e6154b95002f3bb8d40c914861f80fafe6d05bc75161f4b5f49a80ce87120b04c2a383a691020fa1cd031263290000000000000000000000000000000191020fa1cd03d103d203221220002295e47dd7760a9de05b910f104da0279e5c91d0c2960e2c18a9005313dbb9d2032212203130af0a77116b9525df787434c294b51c79e56c9ad44d710d2017087ec24b8a120b04c2a383a691020fa1cc031217290000000000000000000000000000000191020fa1cc03120804c2a383a6060fa11208047f000001060fa1120b047f00000191020fa1cc031217290000000000000000000000000000000191020fa1cd0312142900000000000000000000000000000001060fa1120b047f00000191020fa1cd031257047f00000191020fa1cd03d103d203221220002295e47dd7760a9de05b910f104da0279e5c91d0c2960e2c18a9005313dbb9d2032212203130af0a77116b9525df787434c294b51c79e56c9ad44d710d2017087ec24b8a42f6020a260024080112206d8265230407073f299684d1e32b59523bee2674b5efd4bd48612472c33bc28c120b047f00000191020fa1cc031217290000000000000000000000000000000191020fa1cc031208047f000001060fa11263290000000000000000000000000000000191020fa1cd03d103d20322122078beb0b84978854048de3439586e3263c5e856e5159770ee2b4ec82ad24efbe9d203221220b8ecdef19989425dfff7765e946b195dda850e0fdad4f21491cd485993e7d073120b0495f834d691020fa1cc0312080495f834d6060fa112142900000000000000000000000000000001060fa11217290000000000000000000000000000000191020fa1cd03120b047f00000191020fa1cd03120b0495f834d691020fa1cd031257047f00000191020fa1cd03d103d20322122078beb0b84978854048de3439586e3263c5e856e5159770ee2b4ec82ad24efbe9d203221220b8ecdef19989425dfff7765e946b195dda850e0fdad4f21491cd485993e7d07342f6020a26002408011220ba75521c18d0174e8d057e5068c62cec73519333fe9a4d0d1a66601939cb5566120b0417ef138e91020fa1cc0312080417ef138e060fa11263290000000000000000000000000000000191020fa1cd03d103d203221220f5cec935074cdd748188d2e6492a597adf6d601e7147ed79c75d7b423b0d5e0bd203221220119667c7bb880c61048b28e011bac8d7f20cfe0d28417060d06441bb6cd0f570120b047f00000191020fa1cd031257047f00000191020fa1"
-        )
-
-        let dhtMessage2of2 = Array(
-            hex:
-                "cd03d103d203221220f5cec935074cdd748188d2e6492a597adf6d601e7147ed79c75d7b423b0d5e0bd203221220119667c7bb880c61048b28e011bac8d7f20cfe0d28417060d06441bb6cd0f570120b047f00000191020fa1cc0312142900000000000000000000000000000001060fa11217290000000000000000000000000000000191020fa1cc03120b0417ef138e91020fa1cd031217290000000000000000000000000000000191020fa1cd031208047f000001060fa142b4010a26002408011220f6f0fb5fd04d5b621a326fbfc4a49864056726a45a375d521c9cc292e0fb2d50120b047f00000191020fa1cc0312172920014ba0ffa400be000000000000000191020fa1cc031217290000000000000000000000000000000191020fa1cc0312080459a390c9060fa11208047f000001060fa112142920014ba0ffa400be0000000000000001060fa112142900000000000000000000000000000001060fa1120b0459a390c991020fa1cc0342f6020a2600240801122004837fafbab4c2cc90e9cfaf22587ca501006911bd35e1c64c64a5fb1f98cd7a1208047f000001060fa1120b047f00000191020fa1cd0312142900000000000000000000000000000001060fa11217290000000000000000000000000000000191020fa1cc03120b048c5232b091020fa1cc031208048c5232b0060fa11217290000000000000000000000000000000191020fa1cd03120b047f00000191020fa1cc031263290000000000000000000000000000000191020fa1cd03d103d203221220e93e0e8f51021b7cb352a9205a1aae5ce401b38178bd065c69edf1b41ad78e97d203221220a71a0005582dd24c286034700fb35f5dc718b19f2bc21d390de02b8e1a5068501257047f00000191020fa1cd03d103d203221220e93e0e8f51021b7cb352a9205a1aae5ce401b38178bd065c69edf1b41ad78e97d203221220a71a0005582dd24c286034700fb35f5dc718b19f2bc21d390de02b8e1a506850120b048c5232b091020fa1cd0342f6020a2600240801122099936b6b39e572ae6a739aa1b71d8564732ed374a8e3a914ab207bc9c679f7361217290000000000000000000000000000000191020fa1cd031208045fb3f069060fa1120b047f00000191020fa1cd031257047f00000191020fa1cd03d103d2032212206d1f969798c290fbea3030b17107691acbe17bc65d61228b1f3c3abaa6bf1515d2032212204d975ea6c839f2e10be43574a0ac2c0b6cc81889c2d36506e5edc6064afd833a1263290000000000000000000000000000000191020fa1cd03d103d2032212206d1f969798c290fbea3030b17107691acbe17bc65d61228b1f3c3abaa6bf1515d2032212204d975ea6c839f2e10be43574a0ac2c0b6cc81889c2d36506e5edc6064afd833a1208047f000001060fa1120b045fb3f06991020fa1cc03120b045fb3f06991020fa1cd031217290000000000000000000000000000000191020fa1cc03120b047f00000191020fa1cc0312142900000000000000000000000000000001060fa142560a26002408011220355b4d3353d427b0ff9fb24c514f265ed049eef5ba6b1ffc9588d32b5b330cd11208047f000001060fa1120b047f00000191020fa1cc03120b04593a26f491020fa1cc03120804593a26f4060fa142f6020a2600240801122052737ecce609b58c3cb783265cd093089350f9b2c800da94e79fb1ae283e1fe01217290000000000000000000000000000000191020fa1cd0312142900000000000000000000000000000001060fa1120b04907e8be891020fa1cc031263290000000000000000000000000000000191020fa1cd03d103d203221220150b744122239e08afd3d1a74043d3cf7337a0a0a178bc80ed9d11d5561535e9d203221220737a90ef3f49d95693f1d46eec712c690063650a9423a24e784e4f3c5a8678b51208047f000001060fa11217290000000000000000000000000000000191020fa1cc03120b047f00000191020fa1cc03120b047f00000191020fa1cd03120b04907e8be891020fa1cd03120804907e8be8060fa11257047f00000191020fa1cd03d103d203221220150b744122239e08afd3d1a74043d3cf7337a0a0a178bc80ed9d11d5561535e9d203221220737a90ef3f49d95693f1d46eec712c690063650a9423a24e784e4f3c5a8678b54285010a26002408011220c89dc9e0c45aeb2246083e54b3d5640f41abbda3bd8329b16a684299077c46ac1217290000000000000000000000000000000191020fa1cc031208048233b4a9060fa11208047f000001060fa112142900000000000000000000000000000001060fa1120b048233b4a991020fa1cc03120b047f00000191020fa1cc034283030a260024080112205de9dc2d624fe9c0bac5a20f91b0994006b9abf49b9e21552fb6c0282947ba73120b047f00000191020fa1cc031217290000000000000000000000000000000191020fa1cc03120b044b778d3491020fa1cd031257047f00000191020fa1cd03d103d203221220fb566b0c4d153378afb25f2de4b48f97302aa039c7a7b8906dd95007d97e6abad203221220b93ae1fba91242d96757195a4856a23f3836c76a2053165b6610c723647739a8120b044b778d3491020739cd0312142900000000000000000000000000000001060fa11208047f000001060fa1120b044b778d3491020fa1cc03120b047f00000191020fa1cd031217290000000000000000000000000000000191020fa1cd031208044b778d34060fa11263290000000000000000000000000000000191020fa1cd03d103d203221220fb566b0c4d153378afb25f2de4b48f97302aa039c7a7b8906dd95007d97e6abad203221220b93ae1fba91242d96757195a4856a23f3836c76a2053165b6610c723647739a842f6020a260024080112201cb485da92cd339c0c9221118a666d94dbeb9c055e37720ea140d836eeb14860120b047f00000191020fa1cc03120804acf54460060fa1120b047f00000191020fa1cd031217290000000000000000000000000000000191020fa1cd03120b04acf5446091020fa1cc031208047f000001060fa11263290000000000000000000000000000000191020fa1cd03d103d203221220c0e6d78a2f06047638f6aff26d251e147ac72e01e612bcd7c9a45de676eb758dd203221220f1e3cdea2cc7534dbfeb00324b45442bd366ea140d151d6beba043b7d29641741257047f00000191020fa1cd03d103d203221220c0e6d78a2f06047638f6aff26d251e147ac72e01e612bcd7c9a45de676eb758dd203221220f1e3cdea2cc7534dbfeb00324b45442bd366ea140d151d6beba043b7d29641741217290000000000000000000000000000000191020fa1cc0312142900000000000000000000000000000001060fa1120b04acf5446091020fa1cd0342cc040a26002408011220b707e30439f54fedc1f5f50bf04912af3c62304f849e7a84a0da3a6c54f9d004120b0408d2dce291020fa1cd03120b047f00000191020fa1cc0312080408d2dce2060fa11208047f000001060fa1120b04ac13298f91020fa1cc0312142900000000000000000000000000000001060fa11217290000000000000000000000000000000191020fa1cc031257047f00000191020fa1cd03d103d203221220a5be5592ab0f885ea77b84f990cea5b6dbc3ddde292530add0d70cf95df9a3e6d2032212207ce1ccc1a9ae0c6e9a2dcf72ac2fe80d0e583fb54b2300d81449852bd5041451120b04ac13298f91020fa1cd03120b0408d2dce291020fa1cc0312570408d2dce291020fa1cd03d103d203221220a5be5592ab0f885ea77b84f990cea5b6dbc3ddde292530add0d70cf95df9a3e6d2032212207ce1ccc1a9ae0c6e9a2dcf72ac2fe80d0e583fb54b2300d81449852bd5041451125704ac13298f91020fa1cd03d103d203221220a5be5592ab0f885ea77b84f990cea5b6dbc3ddde292530add0d70cf95df9a3e6d2032212207ce1ccc1a9ae0c6e9a2dcf72ac2fe80d0e583fb54b2300d81449852bd50414511263290000000000000000000000000000000191020fa1cd03d103d203221220a5be5592ab0f885ea77b84f990cea5b6dbc3ddde292530add0d70cf95df9a3e6d2032212207ce1ccc1a9ae0c6e9a2dcf72ac2fe80d0e583fb54b2300d81449852bd5041451120b047f00000191020fa1cd03120804ac13298f060fa11217290000000000000000000000000000000191020fa1cd035001"
-        )
-
-        let prefix = uVarInt(dhtMessage1of2)
-        #expect(prefix.bytesRead == 2)
-        #expect(prefix.value == 7158)
-        #expect(dhtMessage1of2.count + dhtMessage2of2.count == 7160)
-
-        // Ensure we can deserialize the message into a DHT.Message
-        let dht = try DHT.Message(serializedBytes: dhtMessage1of2.dropFirst(prefix.bytesRead) + dhtMessage2of2)
-        #expect(dht.closerPeers.count == 20)
-
-        // Ensure we can create PeerInfo's from the contents of closerPeers
-        for peer in dht.closerPeers {
-            let peerID = try PeerID(fromBytesID: peer.id.byteArray)
-            let addresses = try peer.addrs.map { try Multiaddr($0) }
-            print(PeerInfo(peer: peerID, addresses: addresses))
-        }
-    }
-
-    // MARK: - Provider records
-
-    /// Provider keys are multihashes, not CIDs. We must accept any multihash code, and reject only on
-    /// go's length bound (1...80).
-    @Test func testDHTFauxNetworkQuery_GetProviders_AcceptsAnyMultihash() throws {
-        /// A sha2-256 multihash (this one happens to also be a valid CIDv0)...
-        let sha256Multihash = try Multihash(raw: "provider test", hashedWith: .sha2_256).value
-
-        /// ...and a blake3-256 multihash, hand-assembled as `varint(code) + varint(length) + digest`.
-        /// We build the bytes directly because what matters here is that we accept an arbitrary
-        /// multihash *code*, not that we can compute that hash.
-        let blake3Multihash: [UInt8] = [0x1e, 0x20] + (try LibP2PCrypto.randomBytes(length: 32))
-
-        /// The point of the fix: this key is NOT parseable as a CID, so the old
-        /// `guard let CID = try? CID(key)` would have rejected it outright.
-        #expect(throws: (any Error).self) { try CID(blake3Multihash) }
-        #expect(throws: Never.self) { try CID(sha256Multihash) }
-
-        for key in [sha256Multihash, blake3Multihash] {
-            let decoded = try decodeQueryFrame(try KadDHT.Query.getProviders(key: key).encode())
-            guard case .getProviders(let recovered) = decoded else {
-                Issue.record("Query is not a getProviders for key \(key.toHexString())")
+            guard case .ping = decodedQuery else {
+                Issue.record("Query is not a ping")
                 return
             }
-            #expect(recovered == key)
-        }
-    }
 
-    @Test func testDHTFauxNetworkQuery_GetProviders_RejectsOutOfBoundsKeys() throws {
-        #expect(throws: (any Error).self) { try KadDHT.Query.getProviders(key: []).encode() }
-        #expect(throws: (any Error).self) {
-            try KadDHT.Query.getProviders(key: [UInt8](repeating: 0xAB, count: 81)).encode()
-        }
-        /// Exactly at the bound is fine
-        #expect(throws: Never.self) {
-            try KadDHT.Query.getProviders(key: [UInt8](repeating: 0xAB, count: 80)).encode()
-        }
-    }
+            let response = KadDHT.Response.ping
+            let encodedResponse = try response.encode()
 
-    /// A GET_PROVIDERS response must be able to carry providers *and* closer peers at the same time.
-    @Test func testDHTFauxNetworkResponse_GetProviders_CarriesProvidersAndCloserPeers() throws {
-        let key = try Multihash(raw: "provider test", hashedWith: .sha2_256).value
-        let providers = try (0..<2).map { _ in try DHT.Message.Peer(try generateRandomPeerInfo()) }
-        let closer = try (0..<3).map { _ in try DHT.Message.Peer(try generateRandomPeerInfo()) }
+            /// Send the response back over the wire...
 
-        let decoded = try KadDHT.Response.decode(
-            try KadDHT.Response.getProviders(cid: key, providerPeers: providers, closerPeers: closer).encode()
-        )
+            let decodedResponse = try KadDHT.Response.decode(encodedResponse)
 
-        guard case .getProviders(let recoveredKey, let recoveredProviders, let recoveredCloser) = decoded else {
-            Issue.record("Response is not a getProviders")
-            return
-        }
-
-        #expect(recoveredKey == key)
-        #expect(recoveredProviders.count == 2)
-        #expect(recoveredCloser.count == 3)
-    }
-
-    /// ADD_PROVIDER carries the provider's own PeerInfo in `providerPeers` — that's where a receiving node
-    /// learns the provider's dialable addresses from.
-    @Test func testDHTFauxNetworkQuery_AddProvider_RoundTripsProviderPeers() throws {
-        let key = try Multihash(raw: "provider test", hashedWith: .sha2_256).value
-        let me = try generateRandomPeerInfo()
-
-        let decoded = try decodeQueryFrame(
-            try KadDHT.Query.addProvider(key: key, providerPeers: [try DHT.Message.Peer(me)]).encode()
-        )
-
-        guard case .addProvider(let recoveredKey, let recoveredProviders) = decoded else {
-            Issue.record("Query is not an addProvider")
-            return
-        }
-
-        #expect(recoveredKey == key)
-        #expect(recoveredProviders.count == 1)
-        let recoveredInfo = try recoveredProviders[0].toPeerInfo()
-        #expect(recoveredInfo.peer == me.peer)
-        #expect(recoveredInfo.addresses == me.addresses)
-    }
-
-    // MARK: - PING
-
-    /// Decoding a PING response used to read 8 bytes out of `dht.key` regardless of how many the peer
-    /// actually sent, which is an out-of-bounds read driven by remote input.
-    @Test func testDHTFauxNetworkResponse_Ping_ToleratesArbitraryKeyLengths() throws {
-        for length in [0, 1, 3, 7, 8, 9] {
-            var message = DHT.Message()
-            message.type = .ping
-            if length > 0 { message.key = Data([UInt8](repeating: 0xFF, count: length)) }
-
-            let payload = try message.serializedData()
-            let framed = putUVarInt(UInt64(payload.count)) + [UInt8](payload)
-
-            guard case .ping = try KadDHT.Response.decode(framed) else {
-                Issue.record("Response is not a ping for a \(length) byte key")
+            guard case .ping = decodedResponse else {
+                Issue.record("Response is not a ping")
                 return
+            }
+        }
+
+        @Test func testDHTFauxNetworkQuery_Store_Success() throws {
+            /// Test Query.store and Response.stored
+            let recordToStore = DHT.Record.with({ rec in
+                rec.key = Data("test".utf8)
+                rec.value = Data("Kademlia DHT".utf8)
+            })
+            let query = KadDHT.Query.putValue(key: "test".bytes, record: recordToStore)
+            let encodedQuery = try query.encode()
+
+            /// Send it over the wire...
+
+            let decodedQuery = try decodeQueryFrame(encodedQuery)
+            print("Recovered Query: \(decodedQuery)")
+
+            guard case .putValue(let qKey, let qRecord) = decodedQuery else {
+                Issue.record("Query is not a putValue")
+                return
+            }
+
+            /// Assume we can store the value
+            print("Storing Value: '\(qRecord)' for Key: '\(qKey)'")
+            let response = KadDHT.Response.putValue(key: qKey, record: qRecord)
+            let encodedResponse = try response.encode()
+
+            /// Send the response back over the wire...
+
+            let decodedResponse = try KadDHT.Response.decode(encodedResponse)
+
+            guard case .putValue(let key, let record) = decodedResponse else {
+                Issue.record("Response is not a putValue")
+                return
+            }
+
+            #expect(key == recordToStore.key.byteArray)
+            #expect(record == recordToStore)
+        }
+
+        @Test func testDHTFauxNetworkQuery_Store_Failure() throws {
+            /// Test Query.store and Response.stored
+            let recordToStore = DHT.Record.with({ rec in
+                rec.key = Data("test".utf8)
+                rec.value = Data("hello!".utf8)
+            })
+            let query = KadDHT.Query.putValue(key: "test".bytes, record: recordToStore)
+            let encodedQuery = try query.encode()
+
+            /// Send it over the wire...
+
+            let decodedQuery = try decodeQueryFrame(encodedQuery)
+            print("Recovered Query: \(decodedQuery)")
+
+            guard case .putValue(let key, let value) = decodedQuery else {
+                Issue.record("Query is not a putValue")
+                return
+            }
+
+            /// Assume we can't store the value for some reason
+            print("Failed to store Value: '\(value)' for Key: '\(key)'")
+            let response = KadDHT.Response.putValue(key: "test".bytes, record: nil)
+            let encodedResponse = try response.encode()
+
+            /// Send the response back over the wire...
+
+            let decodedResponse = try KadDHT.Response.decode(encodedResponse)
+
+            guard case .putValue(let key, let value) = decodedResponse else {
+                Issue.record("Response is not a putValue")
+                return
+            }
+
+            #expect(key == "test".bytes)
+            #expect(value == nil)
+        }
+
+        @Test func testDHTFauxNetworkQuery_FindNode() throws {
+            let testAddresses = try (0..<10).map { i -> PeerInfo in
+                let pid = try PeerID(.Ed25519)
+                return try PeerInfo(
+                    peer: pid,
+                    addresses: [Multiaddr("/ip4/127.0.0.1/tcp/\(1000 + i)/p2p/\(pid.b58String)")]
+                )
+            }
+
+            for peerInfo in testAddresses {
+                #expect(throws: Never.self) { try peerInfo.addresses.first?.getPeerID() }
+            }
+
+            /// Test Query.findNode and Response.nodeSearch
+            let targetPeer = testAddresses.first!.peer
+            let query = KadDHT.Query.findNode(key: targetPeer.id)
+            let encodedQuery = try query.encode()
+
+            /// Send it over the wire... (`decodeQueryFrame` unframes first, mirroring the receive path)
+            let decodedQuery = try decodeQueryFrame(encodedQuery)
+            print("Recovered Query: \(decodedQuery)")
+
+            guard case .findNode(let key) = decodedQuery else {
+                Issue.record("Query is not a findNode")
+                return
+            }
+            #expect(key == targetPeer.id)
+
+            let closer = try testAddresses.filter({ $0.peer != targetPeer }).map { try DHT.Message.Peer($0) }
+            let response = KadDHT.Response.findNode(closerPeers: closer)
+            let encodedResponse = try response.encode()
+
+            /// Send the response back over the wire...
+            let decodedResponse = try KadDHT.Response.decode(encodedResponse)
+
+            guard case .findNode(let closerPeers) = decodedResponse else {
+                Issue.record("Response is not a findNode")
+                return
+            }
+
+            print(closerPeers)
+
+            #expect(closerPeers.count == testAddresses.count - 1)
+            // Broken out of the `#expect` macro: the inline `try ... contains(where:) == false` form tripped a
+            // Swift type-checker timeout in this toolchain.
+            let recoveredPeers = try closerPeers.map { try $0.toPeerInfo().peer }
+            #expect(recoveredPeers.contains(targetPeer) == false)
+        }
+
+        /// A FIND_NODE whose key is a *record* key rather than a PeerID must still round-trip.
+        ///
+        /// This is what `PUT_VALUE`/`GET_VALUE` lookups walk towards, and go-libp2p sends those bytes
+        /// verbatim. We used to require the key to parse as a `PeerID`, which rejected them outright.
+        @Test func testDHTFauxNetworkQuery_FindNode_RecordKeyTarget() throws {
+            let pid = try PeerID(.Ed25519)
+            let recordKey = "/pk/".bytes + pid.id
+
+            /// Ensure that this key is NOT a valid PeerID.
+            #expect(throws: (any Error).self) { try PeerID(fromBytesID: recordKey) }
+
+            let encoded = try KadDHT.Query.findNode(key: recordKey).encode()
+            let decoded = try decodeQueryFrame(encoded)
+
+            guard case .findNode(let recovered) = decoded else {
+                Issue.record("Query is not a findNode")
+                return
+            }
+            #expect(recovered == recordKey)
+        }
+
+        /// An empty FIND_NODE key is still rejected.
+        @Test func testDHTFauxNetworkQuery_FindNode_RejectsEmptyKey() throws {
+            #expect(throws: (any Error).self) { try KadDHT.Query.findNode(key: []).encode() }
+        }
+
+        @Test func testDHTFauxNetworkQuery_GetValue_NoValue() throws {
+
+            /// Test Query.findValue and Response.keySearch
+            let query = KadDHT.Query.getValue(key: "test".bytes)
+            let encodedQuery = try query.encode()
+
+            /// Send it over the wire...
+
+            let decodedQuery = try decodeQueryFrame(encodedQuery)
+            print("Recovered Query: \(decodedQuery)")
+
+            guard case .getValue(let key) = decodedQuery else {
+                Issue.record("Query is not a getValue")
+                return
+            }
+
+            print("Key: \(key)")
+            #expect(key == "test".bytes)
+            /// Assume we don't have the key their looking for, so return a set of peers that are closer...
+            let testAddresses = try (0..<3).map {
+                let pid = try PeerID()
+                return try PeerInfo(
+                    peer: pid,
+                    addresses: [Multiaddr("/ip4/127.0.0.1/tcp/\(1000 + $0)/p2p/\(pid.b58String)")]
+                )
+            }
+
+            let response = try KadDHT.Response.getValue(
+                key: "test".bytes,
+                record: nil,
+                closerPeers: testAddresses.map { try DHT.Message.Peer($0) }
+            )
+            let encodedResponse = try response.encode()
+
+            /// Send the response back over the wire...
+
+            let decodedResponse = try KadDHT.Response.decode(encodedResponse)
+
+            guard case .getValue(let key, let record, let closerPeers) = decodedResponse else {
+                Issue.record("Response is not a getValue")
+                return
+            }
+
+            #expect(key == "test".bytes)
+            #expect(record == nil)
+            #expect(closerPeers.count == testAddresses.count)
+        }
+
+        @Test func testDHTFauxNetworkQuery_FindValue_FoundValue() throws {
+
+            /// Test Query.findValue and Response.keySearch
+            let query = KadDHT.Query.getValue(key: "test".bytes)
+            let encodedQuery = try query.encode()
+
+            /// Send it over the wire...
+
+            let decodedQuery = try decodeQueryFrame(encodedQuery)
+            print("Recovered Query: \(decodedQuery)")
+
+            guard case .getValue(let key) = decodedQuery else {
+                Issue.record("Query is not a getValue")
+                return
+            }
+
+            print("Key: \(key)")
+            #expect(key == "test".bytes)
+            /// Assume we have the key they're looking for
+            let value = DHT.Record.with({ rec in
+                rec.key = Data("test".utf8)
+                rec.value = Data("Kademlia DHT".utf8)
+            })
+
+            let response = KadDHT.Response.getValue(key: "test".bytes, record: value, closerPeers: [])
+            let encodedResponse = try response.encode()
+
+            /// Send the response back over the wire...
+
+            let decodedResponse = try KadDHT.Response.decode(encodedResponse)
+
+            guard case .getValue(let key, let record, let closerPeers) = decodedResponse else {
+                Issue.record("Response is not a getValue")
+                return
+            }
+
+            #expect(key == "test".bytes)
+            #expect(record != nil)
+            #expect(record?.key == Data("test".utf8))
+            #expect(record?.value == Data("Kademlia DHT".utf8))
+            #expect(closerPeers.count == 0)
+        }
+
+        // An example of a large response (>4kb) that gets chunked via our inbound stream window buffer.
+        // Make sure we can decode the message in it's entirety
+        @Test func testDecodeDHTMessage() throws {
+            let dhtMessage1of2 = Array(
+                hex:
+                    "f637080442f6020a2600240801122064d6be62f0d67bf0a0a1d232d24badf66219c6ad14bb865b177b8e54a287a6071217290000000000000000000000000000000191020fa1cd03120b04c2f2399991020fa1cd031257047f00000191020fa1cd03d103d2032212200c0599ed33aa478dff2c0b7be3e40fb9f16c4ae2df843e772eea26ae1fd15db5d203221220faf5a659fd020440845c8a58c4ec099d7e03d54a7896bc45a3a5922e54722a3b1217290000000000000000000000000000000191020fa1cc03120804c2f23999060fa1120b047f00000191020fa1cc03120b04c2f2399991020fa1cc03120b047f00000191020fa1cd031263290000000000000000000000000000000191020fa1cd03d103d2032212200c0599ed33aa478dff2c0b7be3e40fb9f16c4ae2df843e772eea26ae1fd15db5d203221220faf5a659fd020440845c8a58c4ec099d7e03d54a7896bc45a3a5922e54722a3b12142900000000000000000000000000000001060fa11208047f000001060fa142f6020a26002408011220d0f66e25d1d87f42164273ad3f509776c989519c282fb7072d6e1b8dde2e8354120b047f00000191020fa1cd031257047f00000191020fa1cd03d103d2032212201462f5f8561d1a5b316278bc8b04e0c275b480f47563e038dc00809b0bdc23cfd20322122060a54b3a3fd85dcc5f4c5f4e2f7c337380086ea019f0aab2c99ed1ac3f0a93e712080468ee984d060fa1120b047f00000191020fa1cc03120b0468ee984d91020fa1cd03120b0468ee984d91020fa1cc031263290000000000000000000000000000000191020fa1cd03d103d2032212201462f5f8561d1a5b316278bc8b04e0c275b480f47563e038dc00809b0bdc23cfd20322122060a54b3a3fd85dcc5f4c5f4e2f7c337380086ea019f0aab2c99ed1ac3f0a93e71208047f000001060fa11217290000000000000000000000000000000191020fa1cd0312142900000000000000000000000000000001060fa11217290000000000000000000000000000000191020fa1cc0342a0050a260024080112208c65b9d3dfb7fba42c9a8e08835795a96e472a4de92faa31ef3c79da53d15888120b04ac1a065591020fa1cd031263290000000000000000000000000000000191020fa1cd03d103d203221220d9e268835631bd78774dd1a4ddcca806bd4a533a6cbc591826a92b66cc49606ad203221220e07f60f86b172ccd5d19c889da586a4339b078049162e7ecd01db371dc3bd1301257047f00000191020fa1cd03d103d203221220d9e268835631bd78774dd1a4ddcca806bd4a533a6cbc591826a92b66cc49606ad203221220e07f60f86b172ccd5d19c889da586a4339b078049162e7ecd01db371dc3bd1301217290000000000000000000000000000000191020fa1cd031217292406da1401b44d00a63d4d0362f1c84491020fa1cd03120b047f00000191020fa1cd0312080412b5b15e060fa1120b0412b5b15e91020fa1cc03120b0412b5b15e91020fa1cd031214292406da1401b44d00a63d4d0362f1c844060fa112142900000000000000000000000000000001060fa11208047f000001060fa11217292406da1401b44d00a63d4d0362f1c84491020fa1cc031217290000000000000000000000000000000191020fa1cc03125704ac1a065591020fa1cd03d103d203221220d9e268835631bd78774dd1a4ddcca806bd4a533a6cbc591826a92b66cc49606ad203221220e07f60f86b172ccd5d19c889da586a4339b078049162e7ecd01db371dc3bd130120804ac1a0655060fa1120b047f00000191020fa1cc03120b04ac1a065591020fa1cc031263292406da1401b44d00a63d4d0362f1c84491020fa1cd03d103d203221220d9e268835631bd78774dd1a4ddcca806bd4a533a6cbc591826a92b66cc49606ad203221220e07f60f86b172ccd5d19c889da586a4339b078049162e7ecd01db371dc3bd13042cf030a26002408011220575e3ace49bc995ac5b2eb5c8c297e834d1e28cdb437fa64a5e601c815c850bd120b048fc6608a91020fa1cc031257048fc6608a91020fa1cd03d103d20322122016e32acbeeb22dde4801df0966a1948d35593ccbcf13756d421af5334ab2840fd203221220cf569c33d875d0d45e2c2a74e2cd224dd5668440494e523c50083fbe90f991d91208047f000001060fa11217290000000000000000000000000000000191020fa1cd031257047f00000191020fa1cd03d103d20322122016e32acbeeb22dde4801df0966a1948d35593ccbcf13756d421af5334ab2840fd203221220cf569c33d875d0d45e2c2a74e2cd224dd5668440494e523c50083fbe90f991d91217290000000000000000000000000000000191020fa1cc031263290000000000000000000000000000000191020fa1cd03d103d20322122016e32acbeeb22dde4801df0966a1948d35593ccbcf13756d421af5334ab2840fd203221220cf569c33d875d0d45e2c2a74e2cd224dd5668440494e523c50083fbe90f991d9120b047f00000191020fa1cd0312142900000000000000000000000000000001060fa1120b047f00000191020fa1cc03120b048fc6608a91020fa1cd031208048fc6608a060fa142f6020a26002408011220228fd5775eec3088959e751d695a74bdacdc2b7dc9d31edebe9413879955028e120b04425e739f91020fa1cd031257047f00000191020fa1cd03d103d203221220ae3bf8e89b681a413c18ab5a1cf44792a734924f0bc70754690af458dd4cb7a5d203221220ef3f5909fb3ec4cf2036eb29bd00e5058389a08c8c14fa4248e72b31714ad22a1217290000000000000000000000000000000191020fa1cc0312142900000000000000000000000000000001060fa1120b04425e739f91020fa1cc03120b047f00000191020fa1cc031217290000000000000000000000000000000191020fa1cd03120804425e739f060fa1120b047f00000191020fa1cd031208047f000001060fa11263290000000000000000000000000000000191020fa1cd03d103d203221220ae3bf8e89b681a413c18ab5a1cf44792a734924f0bc70754690af458dd4cb7a5d203221220ef3f5909fb3ec4cf2036eb29bd00e5058389a08c8c14fa4248e72b31714ad22a42560a260024080112207dce2cdc07849bd25c2e1591e26cbc7e6208ec0ca133867a5b530d9370c3bd541208047f000001060fa1120b047f00000191020fa1cc03120b04339e3d5b91020fa1cc03120804339e3d5b060fa14283030a260024080112201b998427c1492b3453a77ec6349e1464bc2acce02d5d5c68b413dc39a9627633120b045ee7cd1491020fa1cd03120b045ee7cd1491020fa1cc03120b047f00000191020fa1cc031257047f00000191020fa1cd03d103d20322122080a8de3a1493c63aaafef7e4e03db946cd77ca0daaeaba4de3dc4ce56a7325a8d203221220de2326be8c3437c8ea378cc1759df0571bbd30842eacf74b2a42d1919a6a31bd1263290000000000000000000000000000000191020fa1cd03d103d20322122080a8de3a1493c63aaafef7e4e03db946cd77ca0daaeaba4de3dc4ce56a7325a8d203221220de2326be8c3437c8ea378cc1759df0571bbd30842eacf74b2a42d1919a6a31bd1217290000000000000000000000000000000191020fa1cc03120b047f00000191020fa1cd03120b045ee7cd14910206fecd031208045ee7cd14060fa11208047f000001060fa11217290000000000000000000000000000000191020fa1cd0312142900000000000000000000000000000001060fa142f6020a260024080112209afa2952a052536c477605db4f0e0ef6f2e76ea7fd867a7c1b151d517801cd5e1217290000000000000000000000000000000191020fa1cc03120b048f6ea85891020fa1cc031208048f6ea858060fa1120b048f6ea85891020fa1cd03120b047f00000191020fa1cc03120b047f00000191020fa1cd0312142900000000000000000000000000000001060fa11257047f00000191020fa1cd03d103d2032212206e38c8a586b513fbb58885bb0db90f8568a4b10030a3feb443403751efe78bf2d2032212208d3a9aab747a1bb051a3b1ada166ab8ab1720f9148ccf2bfe891227ffb4d9bc01208047f000001060fa11217290000000000000000000000000000000191020fa1cd031263290000000000000000000000000000000191020fa1cd03d103d2032212206e38c8a586b513fbb58885bb0db90f8568a4b10030a3feb443403751efe78bf2d2032212208d3a9aab747a1bb051a3b1ada166ab8ab1720f9148ccf2bfe891227ffb4d9bc042f6020a26002408011220754ea0e6154b95002f3bb8d40c914861f80fafe6d05bc75161f4b5f49a80ce87120b04c2a383a691020fa1cd031263290000000000000000000000000000000191020fa1cd03d103d203221220002295e47dd7760a9de05b910f104da0279e5c91d0c2960e2c18a9005313dbb9d2032212203130af0a77116b9525df787434c294b51c79e56c9ad44d710d2017087ec24b8a120b04c2a383a691020fa1cc031217290000000000000000000000000000000191020fa1cc03120804c2a383a6060fa11208047f000001060fa1120b047f00000191020fa1cc031217290000000000000000000000000000000191020fa1cd0312142900000000000000000000000000000001060fa1120b047f00000191020fa1cd031257047f00000191020fa1cd03d103d203221220002295e47dd7760a9de05b910f104da0279e5c91d0c2960e2c18a9005313dbb9d2032212203130af0a77116b9525df787434c294b51c79e56c9ad44d710d2017087ec24b8a42f6020a260024080112206d8265230407073f299684d1e32b59523bee2674b5efd4bd48612472c33bc28c120b047f00000191020fa1cc031217290000000000000000000000000000000191020fa1cc031208047f000001060fa11263290000000000000000000000000000000191020fa1cd03d103d20322122078beb0b84978854048de3439586e3263c5e856e5159770ee2b4ec82ad24efbe9d203221220b8ecdef19989425dfff7765e946b195dda850e0fdad4f21491cd485993e7d073120b0495f834d691020fa1cc0312080495f834d6060fa112142900000000000000000000000000000001060fa11217290000000000000000000000000000000191020fa1cd03120b047f00000191020fa1cd03120b0495f834d691020fa1cd031257047f00000191020fa1cd03d103d20322122078beb0b84978854048de3439586e3263c5e856e5159770ee2b4ec82ad24efbe9d203221220b8ecdef19989425dfff7765e946b195dda850e0fdad4f21491cd485993e7d07342f6020a26002408011220ba75521c18d0174e8d057e5068c62cec73519333fe9a4d0d1a66601939cb5566120b0417ef138e91020fa1cc0312080417ef138e060fa11263290000000000000000000000000000000191020fa1cd03d103d203221220f5cec935074cdd748188d2e6492a597adf6d601e7147ed79c75d7b423b0d5e0bd203221220119667c7bb880c61048b28e011bac8d7f20cfe0d28417060d06441bb6cd0f570120b047f00000191020fa1cd031257047f00000191020fa1"
+            )
+
+            let dhtMessage2of2 = Array(
+                hex:
+                    "cd03d103d203221220f5cec935074cdd748188d2e6492a597adf6d601e7147ed79c75d7b423b0d5e0bd203221220119667c7bb880c61048b28e011bac8d7f20cfe0d28417060d06441bb6cd0f570120b047f00000191020fa1cc0312142900000000000000000000000000000001060fa11217290000000000000000000000000000000191020fa1cc03120b0417ef138e91020fa1cd031217290000000000000000000000000000000191020fa1cd031208047f000001060fa142b4010a26002408011220f6f0fb5fd04d5b621a326fbfc4a49864056726a45a375d521c9cc292e0fb2d50120b047f00000191020fa1cc0312172920014ba0ffa400be000000000000000191020fa1cc031217290000000000000000000000000000000191020fa1cc0312080459a390c9060fa11208047f000001060fa112142920014ba0ffa400be0000000000000001060fa112142900000000000000000000000000000001060fa1120b0459a390c991020fa1cc0342f6020a2600240801122004837fafbab4c2cc90e9cfaf22587ca501006911bd35e1c64c64a5fb1f98cd7a1208047f000001060fa1120b047f00000191020fa1cd0312142900000000000000000000000000000001060fa11217290000000000000000000000000000000191020fa1cc03120b048c5232b091020fa1cc031208048c5232b0060fa11217290000000000000000000000000000000191020fa1cd03120b047f00000191020fa1cc031263290000000000000000000000000000000191020fa1cd03d103d203221220e93e0e8f51021b7cb352a9205a1aae5ce401b38178bd065c69edf1b41ad78e97d203221220a71a0005582dd24c286034700fb35f5dc718b19f2bc21d390de02b8e1a5068501257047f00000191020fa1cd03d103d203221220e93e0e8f51021b7cb352a9205a1aae5ce401b38178bd065c69edf1b41ad78e97d203221220a71a0005582dd24c286034700fb35f5dc718b19f2bc21d390de02b8e1a506850120b048c5232b091020fa1cd0342f6020a2600240801122099936b6b39e572ae6a739aa1b71d8564732ed374a8e3a914ab207bc9c679f7361217290000000000000000000000000000000191020fa1cd031208045fb3f069060fa1120b047f00000191020fa1cd031257047f00000191020fa1cd03d103d2032212206d1f969798c290fbea3030b17107691acbe17bc65d61228b1f3c3abaa6bf1515d2032212204d975ea6c839f2e10be43574a0ac2c0b6cc81889c2d36506e5edc6064afd833a1263290000000000000000000000000000000191020fa1cd03d103d2032212206d1f969798c290fbea3030b17107691acbe17bc65d61228b1f3c3abaa6bf1515d2032212204d975ea6c839f2e10be43574a0ac2c0b6cc81889c2d36506e5edc6064afd833a1208047f000001060fa1120b045fb3f06991020fa1cc03120b045fb3f06991020fa1cd031217290000000000000000000000000000000191020fa1cc03120b047f00000191020fa1cc0312142900000000000000000000000000000001060fa142560a26002408011220355b4d3353d427b0ff9fb24c514f265ed049eef5ba6b1ffc9588d32b5b330cd11208047f000001060fa1120b047f00000191020fa1cc03120b04593a26f491020fa1cc03120804593a26f4060fa142f6020a2600240801122052737ecce609b58c3cb783265cd093089350f9b2c800da94e79fb1ae283e1fe01217290000000000000000000000000000000191020fa1cd0312142900000000000000000000000000000001060fa1120b04907e8be891020fa1cc031263290000000000000000000000000000000191020fa1cd03d103d203221220150b744122239e08afd3d1a74043d3cf7337a0a0a178bc80ed9d11d5561535e9d203221220737a90ef3f49d95693f1d46eec712c690063650a9423a24e784e4f3c5a8678b51208047f000001060fa11217290000000000000000000000000000000191020fa1cc03120b047f00000191020fa1cc03120b047f00000191020fa1cd03120b04907e8be891020fa1cd03120804907e8be8060fa11257047f00000191020fa1cd03d103d203221220150b744122239e08afd3d1a74043d3cf7337a0a0a178bc80ed9d11d5561535e9d203221220737a90ef3f49d95693f1d46eec712c690063650a9423a24e784e4f3c5a8678b54285010a26002408011220c89dc9e0c45aeb2246083e54b3d5640f41abbda3bd8329b16a684299077c46ac1217290000000000000000000000000000000191020fa1cc031208048233b4a9060fa11208047f000001060fa112142900000000000000000000000000000001060fa1120b048233b4a991020fa1cc03120b047f00000191020fa1cc034283030a260024080112205de9dc2d624fe9c0bac5a20f91b0994006b9abf49b9e21552fb6c0282947ba73120b047f00000191020fa1cc031217290000000000000000000000000000000191020fa1cc03120b044b778d3491020fa1cd031257047f00000191020fa1cd03d103d203221220fb566b0c4d153378afb25f2de4b48f97302aa039c7a7b8906dd95007d97e6abad203221220b93ae1fba91242d96757195a4856a23f3836c76a2053165b6610c723647739a8120b044b778d3491020739cd0312142900000000000000000000000000000001060fa11208047f000001060fa1120b044b778d3491020fa1cc03120b047f00000191020fa1cd031217290000000000000000000000000000000191020fa1cd031208044b778d34060fa11263290000000000000000000000000000000191020fa1cd03d103d203221220fb566b0c4d153378afb25f2de4b48f97302aa039c7a7b8906dd95007d97e6abad203221220b93ae1fba91242d96757195a4856a23f3836c76a2053165b6610c723647739a842f6020a260024080112201cb485da92cd339c0c9221118a666d94dbeb9c055e37720ea140d836eeb14860120b047f00000191020fa1cc03120804acf54460060fa1120b047f00000191020fa1cd031217290000000000000000000000000000000191020fa1cd03120b04acf5446091020fa1cc031208047f000001060fa11263290000000000000000000000000000000191020fa1cd03d103d203221220c0e6d78a2f06047638f6aff26d251e147ac72e01e612bcd7c9a45de676eb758dd203221220f1e3cdea2cc7534dbfeb00324b45442bd366ea140d151d6beba043b7d29641741257047f00000191020fa1cd03d103d203221220c0e6d78a2f06047638f6aff26d251e147ac72e01e612bcd7c9a45de676eb758dd203221220f1e3cdea2cc7534dbfeb00324b45442bd366ea140d151d6beba043b7d29641741217290000000000000000000000000000000191020fa1cc0312142900000000000000000000000000000001060fa1120b04acf5446091020fa1cd0342cc040a26002408011220b707e30439f54fedc1f5f50bf04912af3c62304f849e7a84a0da3a6c54f9d004120b0408d2dce291020fa1cd03120b047f00000191020fa1cc0312080408d2dce2060fa11208047f000001060fa1120b04ac13298f91020fa1cc0312142900000000000000000000000000000001060fa11217290000000000000000000000000000000191020fa1cc031257047f00000191020fa1cd03d103d203221220a5be5592ab0f885ea77b84f990cea5b6dbc3ddde292530add0d70cf95df9a3e6d2032212207ce1ccc1a9ae0c6e9a2dcf72ac2fe80d0e583fb54b2300d81449852bd5041451120b04ac13298f91020fa1cd03120b0408d2dce291020fa1cc0312570408d2dce291020fa1cd03d103d203221220a5be5592ab0f885ea77b84f990cea5b6dbc3ddde292530add0d70cf95df9a3e6d2032212207ce1ccc1a9ae0c6e9a2dcf72ac2fe80d0e583fb54b2300d81449852bd5041451125704ac13298f91020fa1cd03d103d203221220a5be5592ab0f885ea77b84f990cea5b6dbc3ddde292530add0d70cf95df9a3e6d2032212207ce1ccc1a9ae0c6e9a2dcf72ac2fe80d0e583fb54b2300d81449852bd50414511263290000000000000000000000000000000191020fa1cd03d103d203221220a5be5592ab0f885ea77b84f990cea5b6dbc3ddde292530add0d70cf95df9a3e6d2032212207ce1ccc1a9ae0c6e9a2dcf72ac2fe80d0e583fb54b2300d81449852bd5041451120b047f00000191020fa1cd03120804ac13298f060fa11217290000000000000000000000000000000191020fa1cd035001"
+            )
+
+            let prefix = uVarInt(dhtMessage1of2)
+            #expect(prefix.bytesRead == 2)
+            #expect(prefix.value == 7158)
+            #expect(dhtMessage1of2.count + dhtMessage2of2.count == 7160)
+
+            // Ensure we can deserialize the message into a DHT.Message
+            let dht = try DHT.Message(serializedBytes: dhtMessage1of2.dropFirst(prefix.bytesRead) + dhtMessage2of2)
+            #expect(dht.closerPeers.count == 20)
+
+            // Ensure we can create PeerInfo's from the contents of closerPeers
+            for peer in dht.closerPeers {
+                let peerID = try PeerID(fromBytesID: peer.id.byteArray)
+                let addresses = try peer.addrs.map { try Multiaddr($0) }
+                print(PeerInfo(peer: peerID, addresses: addresses))
+            }
+        }
+
+        // MARK: - Provider records
+
+        /// Provider keys are multihashes, not CIDs. We must accept any multihash code, and reject only on
+        /// go's length bound (1...80).
+        @Test func testDHTFauxNetworkQuery_GetProviders_AcceptsAnyMultihash() throws {
+            /// A sha2-256 multihash (this one happens to also be a valid CIDv0)...
+            let sha256Multihash = try Multihash(raw: "provider test", hashedWith: .sha2_256).value
+
+            /// ...and a blake3-256 multihash, hand-assembled as `varint(code) + varint(length) + digest`.
+            /// We build the bytes directly because what matters here is that we accept an arbitrary
+            /// multihash *code*, not that we can compute that hash.
+            let blake3Multihash: [UInt8] = [0x1e, 0x20] + (try LibP2PCrypto.randomBytes(length: 32))
+
+            /// The point of the fix: this key is NOT parseable as a CID, so the old
+            /// `guard let CID = try? CID(key)` would have rejected it outright.
+            #expect(throws: (any Error).self) { try CID(blake3Multihash) }
+            #expect(throws: Never.self) { try CID(sha256Multihash) }
+
+            for key in [sha256Multihash, blake3Multihash] {
+                let decoded = try decodeQueryFrame(try KadDHT.Query.getProviders(key: key).encode())
+                guard case .getProviders(let recovered) = decoded else {
+                    Issue.record("Query is not a getProviders for key \(key.toHexString())")
+                    return
+                }
+                #expect(recovered == key)
+            }
+        }
+
+        @Test func testDHTFauxNetworkQuery_GetProviders_RejectsOutOfBoundsKeys() throws {
+            #expect(throws: (any Error).self) { try KadDHT.Query.getProviders(key: []).encode() }
+            #expect(throws: (any Error).self) {
+                try KadDHT.Query.getProviders(key: [UInt8](repeating: 0xAB, count: 81)).encode()
+            }
+            /// Exactly at the bound is fine
+            #expect(throws: Never.self) {
+                try KadDHT.Query.getProviders(key: [UInt8](repeating: 0xAB, count: 80)).encode()
+            }
+        }
+
+        /// A GET_PROVIDERS response must be able to carry providers *and* closer peers at the same time.
+        @Test func testDHTFauxNetworkResponse_GetProviders_CarriesProvidersAndCloserPeers() throws {
+            let key = try Multihash(raw: "provider test", hashedWith: .sha2_256).value
+            let providers = try (0..<2).map { _ in try DHT.Message.Peer(try generateRandomPeerInfo()) }
+            let closer = try (0..<3).map { _ in try DHT.Message.Peer(try generateRandomPeerInfo()) }
+
+            let decoded = try KadDHT.Response.decode(
+                try KadDHT.Response.getProviders(cid: key, providerPeers: providers, closerPeers: closer).encode()
+            )
+
+            guard case .getProviders(let recoveredKey, let recoveredProviders, let recoveredCloser) = decoded else {
+                Issue.record("Response is not a getProviders")
+                return
+            }
+
+            #expect(recoveredKey == key)
+            #expect(recoveredProviders.count == 2)
+            #expect(recoveredCloser.count == 3)
+        }
+
+        /// ADD_PROVIDER carries the provider's own PeerInfo in `providerPeers` — that's where a receiving node
+        /// learns the provider's dialable addresses from.
+        @Test func testDHTFauxNetworkQuery_AddProvider_RoundTripsProviderPeers() throws {
+            let key = try Multihash(raw: "provider test", hashedWith: .sha2_256).value
+            let me = try generateRandomPeerInfo()
+
+            let decoded = try decodeQueryFrame(
+                try KadDHT.Query.addProvider(key: key, providerPeers: [try DHT.Message.Peer(me)]).encode()
+            )
+
+            guard case .addProvider(let recoveredKey, let recoveredProviders) = decoded else {
+                Issue.record("Query is not an addProvider")
+                return
+            }
+
+            #expect(recoveredKey == key)
+            #expect(recoveredProviders.count == 1)
+            let recoveredInfo = try recoveredProviders[0].toPeerInfo()
+            #expect(recoveredInfo.peer == me.peer)
+            #expect(recoveredInfo.addresses == me.addresses)
+        }
+
+        // MARK: - PING
+
+        /// Decoding a PING response used to read 8 bytes out of `dht.key` regardless of how many the peer
+        /// actually sent, which is an out-of-bounds read driven by remote input.
+        @Test func testDHTFauxNetworkResponse_Ping_ToleratesArbitraryKeyLengths() throws {
+            for length in [0, 1, 3, 7, 8, 9] {
+                var message = DHT.Message()
+                message.type = .ping
+                if length > 0 { message.key = Data([UInt8](repeating: 0xFF, count: length)) }
+
+                let payload = try message.serializedData()
+                let framed = putUVarInt(UInt64(payload.count)) + [UInt8](payload)
+
+                guard case .ping = try KadDHT.Response.decode(framed) else {
+                    Issue.record("Response is not a ping for a \(length) byte key")
+                    return
+                }
             }
         }
     }

--- a/Tests/LibP2PKadDHTTests/MockNetworkTests.swift
+++ b/Tests/LibP2PKadDHTTests/MockNetworkTests.swift
@@ -267,7 +267,7 @@ struct MockNetworkTests {
 
         print("Key: \(key)")
         #expect(key == "test".bytes)
-        /// Assume we have the key their looking for
+        /// Assume we have the key they're looking for
         let value = DHT.Record.with({ rec in
             rec.key = Data("test".utf8)
             rec.value = Data("Kademlia DHT".utf8)

--- a/Tests/LibP2PKadDHTTests/ProvideTests.swift
+++ b/Tests/LibP2PKadDHTTests/ProvideTests.swift
@@ -46,7 +46,11 @@ final class ProvideTests {
         let node = app.dht.kadDHT
 
         // Use a deterministic CID derived from short content.
-        let cid = try CID(version: .v1, codec: .raw, multihash: try Multihash(raw: "phase-3.0-test".bytes, hashedWith: .sha2_256)).rawBuffer
+        let cid = try CID(
+            version: .v1,
+            codec: .raw,
+            multihash: try Multihash(raw: "phase-3.0-test".bytes, hashedWith: .sha2_256)
+        ).rawBuffer
 
         // Provide with announce:false so no network RPCs are sent.
         try node.provide(cid: cid, announce: false).wait()

--- a/Tests/LibP2PKadDHTTests/ProvideTests.swift
+++ b/Tests/LibP2PKadDHTTests/ProvideTests.swift
@@ -24,274 +24,272 @@ import Testing
 
 @testable import LibP2PKadDHT
 
-/// Tests for ``KadDHT.Node/provide(cid:announce:)`` and the related
-/// provider-record renewal + expiry machinery introduced in Phase 3.0.
-///
-/// - Unit-style tests (single-node, no real networking) verify the
-///   state-machine behaviour: local storage, renewal eligibility,
-///   expiry pruning, before-bootstrap handling.
-/// - Integration-style tests (gated by `PerformInternalIntegrationTests=true`,
-///   matching the existing `InternalNetworkTests` convention) verify
-///   real two-node round trips.
-@Suite("Provide Tests", .serialized)
-final class ProvideTests {
+extension LibP2PKadDHTTests {
 
-    // MARK: - Unit-style
-
-    @Test
-    func testProvideStoresLocallyWithoutAnnounce() throws {
-        let app = try makeApplication()
-        defer { app.shutdown() }
-        try app.start()
-        let node = app.dht.kadDHT
-
-        // Use a deterministic CID derived from short content.
-        let cid = try CID(
-            version: .v1,
-            codec: .raw,
-            multihash: try Multihash(raw: "phase-3.0-test".bytes, hashedWith: .sha2_256)
-        ).rawBuffer
-
-        // Provide with announce:false so no network RPCs are sent.
-        try node.provide(cid: cid, announce: false).wait()
-
-        let kid = try providerRoutingKey(cid)
-        let stored = try node.providerStore.getValue(forKey: kid, default: []).wait()
-        #expect(node.localProviderKeys.contains(kid), "localProviderKeys must record the CID")
-        #expect(node.localProviderCIDs[kid] == cid, "localProviderCIDs must preserve the original CID bytes")
-        #expect(stored.count == 1, "providerStore should have exactly our entry; got \(stored.count)")
-        #expect(stored.first?.id == Data(node.peerID.id), "stored provider should be us")
-
-        let composite = KadDHT.Node.providerRecordKey(kid, peerID: node.peerID)
-        #expect(node.providerRecordAddedAt[composite] != nil, "addedAt should be tracked")
-    }
-
-    @Test
-    func testProvideExpiryPruning() throws {
-        let app = try makeApplication()
-        defer { app.shutdown() }
-        try app.start()
-        let node = app.dht.kadDHT
-
-        // Stage: insert a synthetic provider record for a *foreign*
-        // peer with an obviously-stale addedAt timestamp.
-        let foreignPeerID = try PeerID(.Ed25519)
-        let cid = try syntheticCID("expiry-test")
-        let kid = try providerRoutingKey(cid)
-        let foreignInfo = PeerInfo(peer: foreignPeerID, addresses: [])
-        guard let foreignProvider = try? DHT.Message.Peer(foreignInfo) else {
-            Issue.record("could not encode foreign peer")
-            return
-        }
-        try node.providerStore.updateValue([foreignProvider], forKey: kid).wait()
-        let composite = KadDHT.Node.providerRecordKey(kid, peerID: foreignPeerID)
-        node.providerRecordAddedAt[composite] = Date().addingTimeInterval(-25 * 60 * 60)  // 25h ago — past 24h TTL
-
-        // Run expiry; cutoff = now - 24h.
-        let cutoff = Date().addingTimeInterval(-24 * 60 * 60)
-        try node._expireOldProviderRecords(before: cutoff).wait()
-
-        let afterPrune = try node.providerStore.getValue(forKey: kid, default: []).wait()
-        #expect(afterPrune.isEmpty, "expired foreign provider record should be pruned")
-        #expect(node.providerRecordAddedAt[composite] == nil, "stale timestamp entry should be removed")
-    }
-
-    @Test
-    func testProvideRenewalEligibility() throws {
-        let app = try makeApplication()
-        defer { app.shutdown() }
-        try app.start()
-        let node = app.dht.kadDHT
-
-        let cid = try syntheticCID("renewal-test")
-        let kid = try providerRoutingKey(cid)
-        // Set up the local record manually so we can manipulate the
-        // addedAt timestamp before kicking the renewal job.
-        try node.provide(cid: cid, announce: false).wait()
-        let composite = KadDHT.Node.providerRecordKey(kid, peerID: node.peerID)
-
-        // Backdate beyond the republish interval (12h).
-        let staleTime = Date().addingTimeInterval(-13 * 60 * 60)
-        node.providerRecordAddedAt[composite] = staleTime
-
-        // Run the renewal job. With an empty routing table, the
-        // announce path inside the job has no peers to send to, but
-        // the job MUST still refresh our local addedAt timestamp on
-        // completion — otherwise we'd retry on every heartbeat
-        // forever.
-        try node._republishProviderRecords().wait()
-
-        let refreshed = try #require(node.providerRecordAddedAt[composite])
-        #expect(refreshed > staleTime, "renewal job should refresh addedAt past the stale time")
-    }
-
-    @Test
-    func testProvideBeforeBootstrap() throws {
-        let app = try makeApplication()
-        defer { app.shutdown() }
-        try app.start()
-        let node = app.dht.kadDHT
-
-        let cid = try syntheticCID("before-bootstrap")
-        let kid = try providerRoutingKey(cid)
-
-        // Routing table starts empty. provide(announce:true) should
-        // not crash. The iterative lookup finds zero peers; we send
-        // ADD_PROVIDER to zero peers; locally we still record the
-        // CID so a future heartbeat can re-attempt.
-        try node.provide(cid: cid, announce: true).wait()
-
-        #expect(node.localProviderKeys.contains(kid), "local record should be present even without peers")
-        let stored = try node.providerStore.getValue(forKey: kid, default: []).wait()
-        #expect(stored.count == 1, "local provider entry should exist")
-    }
-
-    // MARK: - Integration-style (gated)
-
-    @Test(.internalIntegrationTestsEnabled)
-    func testProvideThenFindRoundTrip() throws {
-        let group = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
-        defer { try! group.syncShutdownGracefully() }
-        let dhtParams = KadDHT.NodeOptions(
-            connectionTimeout: .milliseconds(500),
-            maxConcurrentConnections: 3,
-            bucketSize: 5,
-            maxPeers: 15,
-            maxKeyValueStoreEntries: 10,
-            supportLocalNetwork: true
-        )
-        let nodeA = try makeHost(
-            mode: .server,
-            options: dhtParams,
-            bootstrapPeers: [],
-            usingGroup: .shared(group)
-        )
-        let nodeB = try makeHost(
-            mode: .server,
-            options: dhtParams,
-            bootstrapPeers: [nodeA.peerInfo],
-            usingGroup: .shared(group)
-        )
-        try nodeA.start()
-        try nodeB.start()
-        defer {
-            nodeA.shutdown()
-            nodeB.shutdown()
-        }
-
-        let cid = try syntheticCID("integration-round-trip")
-        try nodeA.dht.kadDHT.provide(cid: cid, announce: true).wait()
-
-        // Give the network a moment to settle.
-        Thread.sleep(forTimeInterval: 0.5)
-
-        let providers = try nodeB.dht.kadDHT.findProviders(cid: cid, count: 4).wait()
-        #expect(!providers.isEmpty, "node B should have found at least one provider for the CID")
-    }
-
-    @Test(.internalIntegrationTestsEnabled)
-    func testProvideMultipleKeys() throws {
-        let group = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
-        defer { try! group.syncShutdownGracefully() }
-        let dhtParams = KadDHT.NodeOptions(
-            connectionTimeout: .milliseconds(500),
-            maxConcurrentConnections: 3,
-            bucketSize: 5,
-            maxPeers: 15,
-            maxKeyValueStoreEntries: 10,
-            supportLocalNetwork: true
-        )
-        let nodeA = try makeHost(
-            mode: .server,
-            options: dhtParams,
-            bootstrapPeers: [],
-            usingGroup: .shared(group)
-        )
-        let nodeB = try makeHost(
-            mode: .server,
-            options: dhtParams,
-            bootstrapPeers: [nodeA.peerInfo],
-            usingGroup: .shared(group)
-        )
-        try nodeA.start()
-        try nodeB.start()
-        defer {
-            nodeA.shutdown()
-            nodeB.shutdown()
-        }
-
-        let cids = try ["key-one", "key-two", "key-three"].map { try syntheticCID($0) }
-        for cid in cids {
-            try nodeA.dht.kadDHT.provide(cid: cid, announce: true).wait()
-        }
-        Thread.sleep(forTimeInterval: 0.5)
-
-        for cid in cids {
-            let providers = try nodeB.dht.kadDHT.findProviders(cid: cid, count: 4).wait()
-            #expect(!providers.isEmpty, "node B should have found a provider for one of the CIDs")
-        }
-    }
-
-    // MARK: - Helpers
-
-    private func syntheticCID(_ tag: String) throws -> [UInt8] {
-        try CID(
-            version: .v1,
-            codec: .raw,
-            multihash: try Multihash(raw: tag.bytes, hashedWith: .sha2_256)
-        ).rawBuffer
-    }
-
-    /// The routing-table key a provider record for `cid` is stored under.
+    /// Tests for ``KadDHT.Node/provide(cid:announce:)`` and the related
+    /// provider-record renewal + expiry machinery introduced in Phase 3.0.
     ///
-    /// Provider records are keyed by the CID's *multihash*, not by the raw CID bytes, so that every
-    /// CID encoding of the same content converges on one key. Tests have to derive the key the same
-    /// way `provide(cid:announce:)` and `findProviders(cid:count:)` do — a CIDv1 `rawBuffer` carries
-    /// a version/codec prefix, so keying off it yields a different (and unreachable) key.
-    private func providerRoutingKey(_ cid: [UInt8]) throws -> KadDHT.Key {
-        KadDHT.Key(try CID(cid).multihash.value, keySpace: .xor)
-    }
+    /// - Unit-style tests (single-node, no real networking) verify the
+    ///   state-machine behaviour: local storage, renewal eligibility,
+    ///   expiry pruning, before-bootstrap handling.
+    /// - Integration-style tests (gated by `PerformInternalIntegrationTests=true`,
+    ///   matching the existing `InternalNetworkTests` convention) verify
+    ///   real two-node round trips.
+    @Suite("Provide Tests", .serialized)
+    final class ProvideTests {
 
-    private func makeApplication() throws -> Application {
-        let lib = try Application(.testing, peerID: PeerID(.Ed25519), eventLoopGroupProvider: .singleton)
-        lib.logger.logLevel = .warning
-        lib.security.use(.noise)
-        lib.muxers.use(.yamux)
-        lib.dht.use(
-            .kadDHT(
-                mode: .client,
-                options: KadDHT.NodeOptions(
-                    connectionTimeout: .milliseconds(150),
-                    maxConcurrentConnections: 3,
-                    bucketSize: 5,
-                    maxPeers: 15,
-                    maxKeyValueStoreEntries: 10,
-                    supportLocalNetwork: true
-                ),
-                bootstrapPeers: [],
-                autoUpdate: false
+        @Test
+        func testProvideStoresLocallyWithoutAnnounce() throws {
+            let app = try makeApplication()
+            defer { app.shutdown() }
+            try app.start()
+            let node = app.dht.kadDHT
+
+            // Use a deterministic CID derived from short content.
+            let cid = try CID(
+                version: .v1,
+                codec: .raw,
+                multihash: try Multihash(raw: "phase-3.0-test".bytes, hashedWith: .sha2_256)
+            ).rawBuffer
+
+            // Provide with announce:false so no network RPCs are sent.
+            try node.provide(cid: cid, announce: false).wait()
+
+            let kid = try providerRoutingKey(cid)
+            let stored = try node.providerStore.getValue(forKey: kid, default: []).wait()
+            #expect(node.localProviderKeys.contains(kid), "localProviderKeys must record the CID")
+            #expect(node.localProviderCIDs[kid] == cid, "localProviderCIDs must preserve the original CID bytes")
+            #expect(stored.count == 1, "providerStore should have exactly our entry; got \(stored.count)")
+            #expect(stored.first?.id == Data(node.peerID.id), "stored provider should be us")
+
+            let composite = KadDHT.Node.providerRecordKey(kid, peerID: node.peerID)
+            #expect(node.providerRecordAddedAt[composite] != nil, "addedAt should be tracked")
+        }
+
+        @Test
+        func testProvideExpiryPruning() throws {
+            let app = try makeApplication()
+            defer { app.shutdown() }
+            try app.start()
+            let node = app.dht.kadDHT
+
+            // Stage: insert a synthetic provider record for a *foreign*
+            // peer with an obviously-stale addedAt timestamp.
+            let foreignPeerID = try PeerID(.Ed25519)
+            let cid = try syntheticCID("expiry-test")
+            let kid = try providerRoutingKey(cid)
+            let foreignInfo = PeerInfo(peer: foreignPeerID, addresses: [])
+            guard let foreignProvider = try? DHT.Message.Peer(foreignInfo) else {
+                Issue.record("could not encode foreign peer")
+                return
+            }
+            try node.providerStore.updateValue([foreignProvider], forKey: kid).wait()
+            let composite = KadDHT.Node.providerRecordKey(kid, peerID: foreignPeerID)
+            node.providerRecordAddedAt[composite] = Date().addingTimeInterval(-25 * 60 * 60)  // 25h ago — past 24h TTL
+
+            // Run expiry; cutoff = now - 24h.
+            let cutoff = Date().addingTimeInterval(-24 * 60 * 60)
+            try node._expireOldProviderRecords(before: cutoff).wait()
+
+            let afterPrune = try node.providerStore.getValue(forKey: kid, default: []).wait()
+            #expect(afterPrune.isEmpty, "expired foreign provider record should be pruned")
+            #expect(node.providerRecordAddedAt[composite] == nil, "stale timestamp entry should be removed")
+        }
+
+        @Test
+        func testProvideRenewalEligibility() throws {
+            let app = try makeApplication()
+            defer { app.shutdown() }
+            try app.start()
+            let node = app.dht.kadDHT
+
+            let cid = try syntheticCID("renewal-test")
+            let kid = try providerRoutingKey(cid)
+            // Set up the local record manually so we can manipulate the
+            // addedAt timestamp before kicking the renewal job.
+            try node.provide(cid: cid, announce: false).wait()
+            let composite = KadDHT.Node.providerRecordKey(kid, peerID: node.peerID)
+
+            // Backdate beyond the republish interval (12h).
+            let staleTime = Date().addingTimeInterval(-13 * 60 * 60)
+            node.providerRecordAddedAt[composite] = staleTime
+
+            // Run the renewal job. With an empty routing table, the
+            // announce path inside the job has no peers to send to, but
+            // the job MUST still refresh our local addedAt timestamp on
+            // completion — otherwise we'd retry on every heartbeat
+            // forever.
+            try node._republishProviderRecords().wait()
+
+            let refreshed = try #require(node.providerRecordAddedAt[composite])
+            #expect(refreshed > staleTime, "renewal job should refresh addedAt past the stale time")
+        }
+
+        @Test
+        func testProvideBeforeBootstrap() throws {
+            let app = try makeApplication()
+            defer { app.shutdown() }
+            try app.start()
+            let node = app.dht.kadDHT
+
+            let cid = try syntheticCID("before-bootstrap")
+            let kid = try providerRoutingKey(cid)
+
+            // Routing table starts empty. provide(announce:true) should
+            // not crash. The iterative lookup finds zero peers; we send
+            // ADD_PROVIDER to zero peers; locally we still record the
+            // CID so a future heartbeat can re-attempt.
+            try node.provide(cid: cid, announce: true).wait()
+
+            #expect(node.localProviderKeys.contains(kid), "local record should be present even without peers")
+            let stored = try node.providerStore.getValue(forKey: kid, default: []).wait()
+            #expect(stored.count == 1, "local provider entry should exist")
+        }
+
+        func testProvideThenFindRoundTrip() throws {
+            let group = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
+            defer { try! group.syncShutdownGracefully() }
+            let dhtParams = KadDHT.NodeOptions(
+                connectionTimeout: .milliseconds(500),
+                maxConcurrentConnections: 3,
+                bucketSize: 5,
+                maxPeers: 15,
+                maxKeyValueStoreEntries: 10,
+                supportLocalNetwork: true
             )
-        )
-        lib.servers.use(.tcp(host: "127.0.0.1", port: self.nextPort))
-        self.nextPort += 1
-        return lib
+            let nodeA = try makeHost(
+                mode: .server,
+                options: dhtParams,
+                bootstrapPeers: [],
+                usingGroup: .shared(group)
+            )
+            let nodeB = try makeHost(
+                mode: .server,
+                options: dhtParams,
+                bootstrapPeers: [nodeA.peerInfo],
+                usingGroup: .shared(group)
+            )
+            try nodeA.start()
+            try nodeB.start()
+            defer {
+                nodeA.shutdown()
+                nodeB.shutdown()
+            }
+
+            let cid = try syntheticCID("integration-round-trip")
+            try nodeA.dht.kadDHT.provide(cid: cid, announce: true).wait()
+
+            // Give the network a moment to settle.
+            Thread.sleep(forTimeInterval: 0.5)
+
+            let providers = try nodeB.dht.kadDHT.findProviders(cid: cid, count: 4).wait()
+            #expect(!providers.isEmpty, "node B should have found at least one provider for the CID")
+        }
+
+        func testProvideMultipleKeys() throws {
+            let group = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
+            defer { try! group.syncShutdownGracefully() }
+            let dhtParams = KadDHT.NodeOptions(
+                connectionTimeout: .milliseconds(500),
+                maxConcurrentConnections: 3,
+                bucketSize: 5,
+                maxPeers: 15,
+                maxKeyValueStoreEntries: 10,
+                supportLocalNetwork: true
+            )
+            let nodeA = try makeHost(
+                mode: .server,
+                options: dhtParams,
+                bootstrapPeers: [],
+                usingGroup: .shared(group)
+            )
+            let nodeB = try makeHost(
+                mode: .server,
+                options: dhtParams,
+                bootstrapPeers: [nodeA.peerInfo],
+                usingGroup: .shared(group)
+            )
+            try nodeA.start()
+            try nodeB.start()
+            defer {
+                nodeA.shutdown()
+                nodeB.shutdown()
+            }
+
+            let cids = try ["key-one", "key-two", "key-three"].map { try syntheticCID($0) }
+            for cid in cids {
+                try nodeA.dht.kadDHT.provide(cid: cid, announce: true).wait()
+            }
+            Thread.sleep(forTimeInterval: 0.5)
+
+            for cid in cids {
+                let providers = try nodeB.dht.kadDHT.findProviders(cid: cid, count: 4).wait()
+                #expect(!providers.isEmpty, "node B should have found a provider for one of the CIDs")
+            }
+        }
+
+        // MARK: - Helpers
+
+        private func syntheticCID(_ tag: String) throws -> [UInt8] {
+            try CID(
+                version: .v1,
+                codec: .raw,
+                multihash: try Multihash(raw: tag.bytes, hashedWith: .sha2_256)
+            ).rawBuffer
+        }
+
+        /// The routing-table key a provider record for `cid` is stored under.
+        ///
+        /// Provider records are keyed by the CID's *multihash*, not by the raw CID bytes, so that every
+        /// CID encoding of the same content converges on one key. Tests have to derive the key the same
+        /// way `provide(cid:announce:)` and `findProviders(cid:count:)` do — a CIDv1 `rawBuffer` carries
+        /// a version/codec prefix, so keying off it yields a different (and unreachable) key.
+        private func providerRoutingKey(_ cid: [UInt8]) throws -> KadDHT.Key {
+            KadDHT.Key(try CID(cid).multihash.value, keySpace: .xor)
+        }
+
+        private func makeApplication() throws -> Application {
+            let lib = try Application(.testing, peerID: PeerID(.Ed25519), eventLoopGroupProvider: .singleton)
+            lib.logger.logLevel = .warning
+            lib.security.use(.noise)
+            lib.muxers.use(.yamux)
+            lib.dht.use(
+                .kadDHT(
+                    mode: .client,
+                    options: KadDHT.NodeOptions(
+                        connectionTimeout: .milliseconds(150),
+                        maxConcurrentConnections: 3,
+                        bucketSize: 5,
+                        maxPeers: 15,
+                        maxKeyValueStoreEntries: 10,
+                        supportLocalNetwork: true
+                    ),
+                    bootstrapPeers: [],
+                    autoUpdate: false
+                )
+            )
+            lib.servers.use(.tcp(host: "127.0.0.1", port: self.nextPort))
+            self.nextPort += 1
+            return lib
+        }
+
+        private var nextPort: Int = 11000
+
+        private func makeHost(
+            mode: KadDHT.Mode = .client,
+            options: KadDHT.NodeOptions = .default,
+            bootstrapPeers: [PeerInfo] = [],
+            usingGroup: Application.EventLoopGroupProvider = .singleton
+        ) throws -> Application {
+            let lib = try Application(.testing, peerID: PeerID(.Ed25519), eventLoopGroupProvider: usingGroup)
+            lib.logger.logLevel = .warning
+            lib.security.use(.noise)
+            lib.muxers.use(.yamux)
+            lib.dht.use(.kadDHT(mode: mode, options: options, bootstrapPeers: bootstrapPeers, autoUpdate: false))
+            lib.servers.use(.tcp(host: "127.0.0.1", port: self.nextPort))
+            self.nextPort += 1
+            return lib
+        }
     }
 
-    private var nextPort: Int = 11000
-
-    private func makeHost(
-        mode: KadDHT.Mode = .client,
-        options: KadDHT.NodeOptions = .default,
-        bootstrapPeers: [PeerInfo] = [],
-        usingGroup: Application.EventLoopGroupProvider = .singleton
-    ) throws -> Application {
-        let lib = try Application(.testing, peerID: PeerID(.Ed25519), eventLoopGroupProvider: usingGroup)
-        lib.logger.logLevel = .warning
-        lib.security.use(.noise)
-        lib.muxers.use(.yamux)
-        lib.dht.use(.kadDHT(mode: mode, options: options, bootstrapPeers: bootstrapPeers, autoUpdate: false))
-        lib.servers.use(.tcp(host: "127.0.0.1", port: self.nextPort))
-        self.nextPort += 1
-        return lib
-    }
 }

--- a/Tests/LibP2PKadDHTTests/RoutingTableTests.swift
+++ b/Tests/LibP2PKadDHTTests/RoutingTableTests.swift
@@ -19,1129 +19,1133 @@ import Testing
 
 @testable import LibP2PKadDHT
 
-@Suite("Routing Table Tests", .serialized)
-struct RoutingTableTests {
+extension LibP2PKadDHTTests {
 
-    @Test func testBucketMinimum() {
-        var bucket = Bucket()
+    @Suite("Routing Table Tests", .serialized)
+    struct RoutingTableTests {
 
-        let pid3 = RandomDHTPeer()  // We initialize pid3 first so it has the oldest LastUsefulAt value
-        let pid1 = RandomDHTPeer()  // Then pid1
-        let pid2 = RandomDHTPeer()  // Then pid2
+        @Test func testBucketMinimum() {
+            var bucket = Bucket()
 
-        /// pid1 should be first
-        bucket.pushFront(pid1)
-        /// Sorting LastUsefulAt from oldest to newest, pid1 should be the oldest at index 0
-        #expect(
-            pid1
-                == bucket.min(by: { lhs, rhs in
-                    lhs.lastUsefulAt! < rhs.lastUsefulAt!
-                })
-        )
+            let pid3 = RandomDHTPeer()  // We initialize pid3 first so it has the oldest LastUsefulAt value
+            let pid1 = RandomDHTPeer()  // Then pid1
+            let pid2 = RandomDHTPeer()  // Then pid2
 
-        /// pid1 should still be first
-        bucket.pushFront(pid2)
-        /// Sorting LastUsefulAt from oldest to newest, pid1 should still be the oldest at index 0
-        #expect(
-            pid1
-                == bucket.min(by: { lhs, rhs in
-                    lhs.lastUsefulAt! < rhs.lastUsefulAt!
-                })
-        )
+            /// pid1 should be first
+            bucket.pushFront(pid1)
+            /// Sorting LastUsefulAt from oldest to newest, pid1 should be the oldest at index 0
+            #expect(
+                pid1
+                    == bucket.min(by: { lhs, rhs in
+                        lhs.lastUsefulAt! < rhs.lastUsefulAt!
+                    })
+            )
 
-        /// pid3 should be first now...
-        bucket.pushFront(pid3)
-        /// Sorting LastUsefulAt from oldest to newest, pid3 should now be the oldest at index 0
-        #expect(
-            pid3
-                == bucket.min(by: { lhs, rhs in
-                    lhs.lastUsefulAt! < rhs.lastUsefulAt!
-                })
-        )
-    }
+            /// pid1 should still be first
+            bucket.pushFront(pid2)
+            /// Sorting LastUsefulAt from oldest to newest, pid1 should still be the oldest at index 0
+            #expect(
+                pid1
+                    == bucket.min(by: { lhs, rhs in
+                        lhs.lastUsefulAt! < rhs.lastUsefulAt!
+                    })
+            )
 
-    @Test func testBucketUpdateAllWith() {
-        var bucket = Bucket()
-
-        let pid1 = RandomDHTPeer()
-        let pid2 = RandomDHTPeer()
-        let pid3 = RandomDHTPeer()
-
-        /// Peer1
-        bucket.pushFront(pid1)
-        #expect(bucket[0].replaceable == false)
-        bucket.updateAllWith { peer in
-            peer.replaceable = true
-        }
-        #expect(bucket[0].replaceable)
-
-        /// Peer2
-        bucket.pushFront(pid2)
-        #expect(bucket[0].replaceable == false)
-        bucket.updateAllWith { peer in
-            if peer.id == pid1.id {
-                peer.replaceable = false
-            } else {
-                peer.replaceable = true
-            }
-        }
-        #expect(bucket.getPeer(pid2.id)!.replaceable)
-        #expect(bucket.getPeer(pid1.id)!.replaceable == false)
-
-        /// Peer3
-        bucket.pushFront(pid3)
-        #expect(bucket.getPeer(pid3.id)!.replaceable == false)
-        bucket.updateAllWith { peer in
-            peer.replaceable = true
-        }
-        #expect(bucket.getPeer(pid1.id)!.replaceable)
-        #expect(bucket.getPeer(pid2.id)!.replaceable)
-        #expect(bucket.getPeer(pid3.id)!.replaceable)
-    }
-
-    @Test func testRoutingTablePrintDescription() throws {
-        // We use a static example PeerID here so our printed description is deterministic
-        let peerPEM = """
-            -----BEGIN PRIVATE KEY-----
-            MC4CAQAwBQYDK2VwBCIEIK9RIMMES4Lb9FBQ8RFp7BjBxYRp8k9Azvehdb4EOb9L
-            -----END PRIVATE KEY-----
-            """
-        let peer = try PeerID(pem: peerPEM, password: nil)
-
-        let elg = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        let routingTable = RoutingTable(
-            eventloop: elg.next(),
-            bucketSize: 1,
-            localPeerID: peer,
-            latency: .hours(1),
-            peerstoreMetrics: [:],
-            usefulnessGracePeriod: .hours(1)
-        )
-
-        let desc = """
-            📒 --------------------------------- 📒
-            Routing Table [<peer.ID ChmLdj>]
-            Bucket Count: 1 buckets of size: 1
-            Total Peers: 0
-            b[0] = []
-            ---------------------------------------
-            """
-
-        #expect(routingTable.description.trimmingCharacters(in: .whitespacesAndNewlines) == desc)
-        try elg.syncShutdownGracefully()
-    }
-
-    @Test func testBasicBucketFunctions() throws {
-        let peerCount = 100
-        var bucket = Bucket()
-
-        let local = try PeerID(.Ed25519)
-        let localID = KadDHT.Key(local)
-
-        let time1 = Date().timeIntervalSince1970
-        let time2 = Date().timeIntervalSince1970 + 10
-
-        let peers: [PeerID] = (0..<peerCount).map { _ in try! PeerID(.Ed25519) }
-        for peer in peers {
-            bucket.pushFront(
-                DHTPeerInfo(
-                    id: peer,
-                    lastUsefulAt: time1,
-                    lastSuccessfulOutboundQueryAt: time2,
-                    addedAt: time1,
-                    dhtID: KadDHT.Key(peer),
-                    replaceable: false
-                )
+            /// pid3 should be first now...
+            bucket.pushFront(pid3)
+            /// Sorting LastUsefulAt from oldest to newest, pid3 should now be the oldest at index 0
+            #expect(
+                pid3
+                    == bucket.min(by: { lhs, rhs in
+                        lhs.lastUsefulAt! < rhs.lastUsefulAt!
+                    })
             )
         }
 
-        /// Assert that all 100 peers were added to the bucket
-        #expect(bucket.peers().count == peerCount)
+        @Test func testBucketUpdateAllWith() {
+            var bucket = Bucket()
 
-        /// Modifying a peer in a bucket via unsafeMutablePointer
-        let newTime2 = Date().timeIntervalSince1970 + 3600
-        let newTime3 = newTime2 + 3600
+            let pid1 = RandomDHTPeer()
+            let pid2 = RandomDHTPeer()
+            let pid3 = RandomDHTPeer()
 
-        /// Select a random peer and make sure it was instantiated correctly
-        let randomIndex = Int.random(in: 0..<peerCount)
-        bucket.getPeer(peers[randomIndex]) { randomPeer in
-            print("Running Modifier on \(randomPeer.id)")
-            #expect(peers[randomIndex] == randomPeer.id)
-            #expect(KadDHT.Key(peers[randomIndex]) == randomPeer.dhtID)
-            #expect(randomPeer.lastUsefulAt == time1)
-            #expect(randomPeer.lastSuccessfulOutboundQueryAt == time2)
+            /// Peer1
+            bucket.pushFront(pid1)
+            #expect(bucket[0].replaceable == false)
+            bucket.updateAllWith { peer in
+                peer.replaceable = true
+            }
+            #expect(bucket[0].replaceable)
 
-            /// Modify the peer in place...
-            randomPeer.lastSuccessfulOutboundQueryAt = newTime2
-            randomPeer.lastUsefulAt = newTime3
+            /// Peer2
+            bucket.pushFront(pid2)
+            #expect(bucket[0].replaceable == false)
+            bucket.updateAllWith { peer in
+                if peer.id == pid1.id {
+                    peer.replaceable = false
+                } else {
+                    peer.replaceable = true
+                }
+            }
+            #expect(bucket.getPeer(pid2.id)!.replaceable)
+            #expect(bucket.getPeer(pid1.id)!.replaceable == false)
+
+            /// Peer3
+            bucket.pushFront(pid3)
+            #expect(bucket.getPeer(pid3.id)!.replaceable == false)
+            bucket.updateAllWith { peer in
+                peer.replaceable = true
+            }
+            #expect(bucket.getPeer(pid1.id)!.replaceable)
+            #expect(bucket.getPeer(pid2.id)!.replaceable)
+            #expect(bucket.getPeer(pid3.id)!.replaceable)
         }
 
-        /// Ensure our modification were realized
-        let randomPeer = bucket.getPeer(peers[randomIndex])
-        print("Checking Modification on \(randomPeer!.id)")
-        #expect(randomPeer?.lastSuccessfulOutboundQueryAt == newTime2)
-        #expect(randomPeer?.lastUsefulAt == newTime3)
+        @Test func testRoutingTablePrintDescription() throws {
+            // We use a static example PeerID here so our printed description is deterministic
+            let peerPEM = """
+                -----BEGIN PRIVATE KEY-----
+                MC4CAQAwBQYDK2VwBCIEIK9RIMMES4Lb9FBQ8RFp7BjBxYRp8k9Azvehdb4EOb9L
+                -----END PRIVATE KEY-----
+                """
+            let peer = try PeerID(pem: peerPEM, password: nil)
 
-        let split = bucket.split(commonPrefixLength: 0, targetID: localID.bytes)
+            let elg = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+            let routingTable = RoutingTable(
+                eventloop: elg.next(),
+                bucketSize: 1,
+                localPeerID: peer,
+                latency: .hours(1),
+                peerstoreMetrics: [:],
+                usefulnessGracePeriod: .hours(1)
+            )
 
-        print("Bucket Count Post Split: \(bucket.count)")
-        print("New Bucket (non 0 cpls) Count: \(split.count)")
+            let desc = """
+                📒 --------------------------------- 📒
+                Routing Table [<peer.ID ChmLdj>]
+                Bucket Count: 1 buckets of size: 1
+                Total Peers: 0
+                b[0] = []
+                ---------------------------------------
+                """
 
-        print(localID.bytes)
-
-        /// Bucket should be peers with a CPL == 0
-        for dhtPeer in bucket.peers() {
-            let cpl = local.commonPrefixLength(with: dhtPeer.id)
-            //print(dhtPeer.dhtID.bytes)
-            #expect(cpl == 0)
-        }
-        /// Split should contain only peers who's CPL > 0
-        for dhtPeer in split.peers() {
-            let cpl = local.commonPrefixLength(with: dhtPeer.id)
-            print(dhtPeer.dhtID.bytes)
-            #expect(cpl > 0)
-        }
-    }
-
-    @Test func testRandomDHTKeyCPL() throws {
-        let local = RandomDHTKey()
-
-        let similar0 = RandomDHTKey(withCPL: 0, wrt: local)
-        #expect(local.commonPrefixLength(with: similar0) == 0)
-
-        let similar1 = RandomDHTKey(withCPL: 1, wrt: local)
-        #expect(local.commonPrefixLength(with: similar1) == 1)
-
-        let similar2 = RandomDHTKey(withCPL: 2, wrt: local)
-        #expect(local.commonPrefixLength(with: similar2) == 2)
-
-        let similar3 = RandomDHTKey(withCPL: 3, wrt: local)
-        #expect(local.commonPrefixLength(with: similar3) == 3)
-
-        let similar4 = RandomDHTKey(withCPL: 4, wrt: local)
-        #expect(local.commonPrefixLength(with: similar4) == 4)
-
-        let similar5 = RandomDHTKey(withCPL: 5, wrt: local)
-        #expect(local.commonPrefixLength(with: similar5) == 5)
-
-        let similar6 = RandomDHTKey(withCPL: 6, wrt: local)
-        #expect(local.commonPrefixLength(with: similar6) == 6)
-
-        let similar7 = RandomDHTKey(withCPL: 7, wrt: local)
-        #expect(local.commonPrefixLength(with: similar7) == 7)
-
-        let similar8 = RandomDHTKey(withCPL: 8, wrt: local)
-        #expect(local.commonPrefixLength(with: similar8) == 8)
-
-        let similar9 = RandomDHTKey(withCPL: 9, wrt: local)
-        #expect(local.commonPrefixLength(with: similar9) == 9)
-    }
-
-    /// - TODO: We're confusing DHTPeer and PeerIDs at the moment... We should update the Routing Table to handle DHTPeers instead of PeerID
-    @Test func testBucketGetPeersByCPL() throws {
-        let local = RandomDHTPeer()
-
-        print(local.id)
-        print(local.dhtID.bytes)
-
-        let elg = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        let routingTable = RoutingTable(
-            eventloop: elg.next(),
-            bucketSize: 2,
-            localPeerID: local.id,
-            latency: .hours(1),
-            peerstoreMetrics: [:],
-            usefulnessGracePeriod: .hours(1)
-        )
-
-        #expect(try 0 == routingTable.numberOfPeers(withCommonPrefixLength: 0).wait())
-        #expect(try 0 == routingTable.numberOfPeers(withCommonPrefixLength: 1).wait())
-
-        /// Generate and add a peer with a commonPrefixLength of 1 w.r.t our local peer id
-        let peerCPL1 = RandomDHTPeer(withCPL: 1, wrt: local.dhtID)
-        #expect(
-            try routingTable.addPeer(peerCPL1, isQueryPeer: true, replacementStrategy: .anyReplaceable).wait()
-        )
-        print("Added peer: \(peerCPL1.dhtID.bytes)")
-        print(routingTable)
-        #expect(try 0 == routingTable.numberOfPeers(withCommonPrefixLength: 0).wait())
-        #expect(try 1 == routingTable.numberOfPeers(withCommonPrefixLength: 1).wait())
-        #expect(try 0 == routingTable.numberOfPeers(withCommonPrefixLength: 2).wait())
-
-        /// Generate and add a peer with a commonPrefixLength of 0 w.r.t our local peer id
-        let peerCPL0 = RandomDHTPeer(withCPL: 0, wrt: local.dhtID)
-        #expect(
-            try routingTable.addPeer(peerCPL0, isQueryPeer: true, replacementStrategy: .anyReplaceable).wait()
-        )
-        print("Added peer: \(peerCPL0.dhtID.bytes)")
-        print(routingTable)
-        #expect(try 1 == routingTable.numberOfPeers(withCommonPrefixLength: 0).wait())
-        #expect(try 1 == routingTable.numberOfPeers(withCommonPrefixLength: 1).wait())
-        #expect(try 0 == routingTable.numberOfPeers(withCommonPrefixLength: 2).wait())
-
-        /// Generate and add a peer with a commonPrefixLength of 1 w.r.t our local peer id
-        /// Adding a third peer will force a bucket split when our bucketSize param is set to 2
-        let peerCPL1_2 = RandomDHTPeer(withCPL: 1, wrt: local.dhtID)
-        #expect(
-            try routingTable.addPeer(peerCPL1_2, isQueryPeer: true, replacementStrategy: .anyReplaceable).wait()
-        )
-        print("Added peer: \(peerCPL1_2.dhtID.bytes)")
-        print(routingTable)
-        #expect(try 1 == routingTable.numberOfPeers(withCommonPrefixLength: 0).wait())
-        #expect(try 2 == routingTable.numberOfPeers(withCommonPrefixLength: 1).wait())
-        #expect(try 0 == routingTable.numberOfPeers(withCommonPrefixLength: 2).wait())
-
-        /// Generate and add a peer with a commonPrefixLength of 0 w.r.t our local peer id
-        let peerCPL0_2 = RandomDHTPeer(withCPL: 0, wrt: local.dhtID)
-        #expect(
-            try routingTable.addPeer(peerCPL0_2, isQueryPeer: true, replacementStrategy: .anyReplaceable).wait()
-        )
-        print("Added peer: \(peerCPL0_2.dhtID.bytes)")
-        print(routingTable)
-        #expect(try 2 == routingTable.numberOfPeers(withCommonPrefixLength: 0).wait())
-        #expect(try 2 == routingTable.numberOfPeers(withCommonPrefixLength: 1).wait())
-        #expect(try 0 == routingTable.numberOfPeers(withCommonPrefixLength: 2).wait())
-
-        /// Generate and add a peer with a commonPrefixLength of 1 w.r.t our local peer id
-        /// Attempting to add a third peer with a CPL of 1 will force a bucket split but will fail to add the peer due to the bucket for CPL 1's being full
-        /// And the fact that all of the peers added so far have their replaceable param set to false
-        let peerCPL1_3 = RandomDHTPeer(withCPL: 1, wrt: local.dhtID)
-        #expect(
-            try routingTable.addPeer(peerCPL1_3, isQueryPeer: true, replacementStrategy: .anyReplaceable).wait()
-                == false
-        )
-        print(routingTable)
-
-        /// Attempting Again Fails
-        let peerCPL1_4 = RandomDHTPeer(withCPL: 1, wrt: local.dhtID)
-        #expect(
-            try routingTable.addPeer(peerCPL1_4, isQueryPeer: true, replacementStrategy: .anyReplaceable).wait()
-                == false
-        )
-        print(routingTable)
-
-        /// Generate and add a peer with a commonPrefixLength of 2 w.r.t our local peer id
-        /// Adding this peer should succeed due to having excess capacity in bucket[2]
-        let peerCPL2_1 = RandomDHTPeer(withCPL: 2, wrt: local.dhtID)
-        #expect(
-            try routingTable.addPeer(peerCPL2_1, isQueryPeer: true, replacementStrategy: .anyReplaceable).wait()
-        )
-        print("Added peer: \(peerCPL2_1.dhtID.bytes)")
-        print(routingTable)
-        #expect(try 2 == routingTable.numberOfPeers(withCommonPrefixLength: 0).wait())
-        #expect(try 2 == routingTable.numberOfPeers(withCommonPrefixLength: 1).wait())
-        #expect(try 1 == routingTable.numberOfPeers(withCommonPrefixLength: 2).wait())
-
-        /// TODO: Mark a peer as replaceable and attempt to add a peer in it's place
-
-        try elg.syncShutdownGracefully()
-    }
-
-    @Test func testEmptyBucketCollapse() throws {
-
-        let local = RandomDHTPeer()
-
-        print(local.id)
-        print(local.dhtID.bytes)
-
-        let elg = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        defer { try! elg.syncShutdownGracefully() }
-
-        let routingTable = RoutingTable(
-            eventloop: elg.next(),
-            bucketSize: 1,
-            localPeerID: local.id,
-            latency: .hours(1),
-            peerstoreMetrics: [:],
-            usefulnessGracePeriod: .hours(1)
-        )
-        routingTable.logLevel = .debug
-
-        /// Generate Peers with CPLs of 0, 1, 2 and 3
-        let peer0 = RandomDHTPeer(withCPL: 0, wrt: local.dhtID)
-        let peer1 = RandomDHTPeer(withCPL: 1, wrt: local.dhtID)
-        let peer2 = RandomDHTPeer(withCPL: 2, wrt: local.dhtID)
-        let peer3 = RandomDHTPeer(withCPL: 3, wrt: local.dhtID)
-
-        /// Removing a peer on an empty bucket shouldn't throw an error
-        #expect(throws: Never.self) { try routingTable.removePeer(peer0).wait() }
-
-        /// Add and then remove peer0, this should create a bucket[0]
-        #expect(try routingTable.addPeer(peer0, isQueryPeer: true, replacementStrategy: .anyReplaceable).wait())
-        /// Removing the peer from the bucket shouldn't cause the bucket to disappear due to it being the only bucket we have
-        #expect(try routingTable.removePeer(peer0).wait())
-        #expect(try routingTable.bucketCount.wait() == 1)
-        #expect(try routingTable.getPeerInfos().wait().count == 0)
-        print(routingTable)
-
-        /// Add peer with CPL 0 and 1 and verify that our RoutingTable has 2 buckets
-        #expect(try routingTable.addPeer(peer0, isQueryPeer: true, replacementStrategy: .anyReplaceable).wait())
-        #expect(try routingTable.addPeer(peer1, isQueryPeer: true, replacementStrategy: .anyReplaceable).wait())
-        #expect(try routingTable.bucketCount.wait() == 2)
-        #expect(try routingTable.getPeerInfos().wait().count == 2)
-        print(routingTable)
-
-        /// Removing a peer from the last bucket should cause it to collapse
-        #expect(try routingTable.removePeer(peer1).wait())
-        #expect(try routingTable.bucketCount.wait() == 1)
-        #expect(try routingTable.getPeerInfos().wait().count == 1)
-        #expect(try routingTable.getPeerInfos().wait().contains(where: { $0.id == peer0.id }))
-        //print(try routingTable.getPeerInfos().wait())
-        print(routingTable)
-
-        /// Add peer with CPL 1 again and verify that our RoutingTable has 2 buckets
-        #expect(try routingTable.addPeer(peer1, isQueryPeer: true, replacementStrategy: .anyReplaceable).wait())
-        #expect(try routingTable.bucketCount.wait() == 2)
-        #expect(try routingTable.getPeerInfos().wait().count == 2)
-        print(routingTable)
-
-        /// Remove a peer from the second to last bucket (the first bucket in this case) and ensure it collapses as expected
-        #expect(try routingTable.removePeer(peer0).wait())
-        #expect(try routingTable.bucketCount.wait() == 1)
-        #expect(try routingTable.getPeerInfos().wait().count == 1)
-        #expect(try routingTable.getPeerInfos().wait().contains(where: { $0.id == peer1.id }))
-        print(routingTable)
-
-        /// Add all four peers and expect 4 buckets (peer1 shouldn't be added twice)
-        #expect(try routingTable.addPeer(peer0, isQueryPeer: true, replacementStrategy: .anyReplaceable).wait())
-        #expect(
-            try routingTable.addPeer(peer1, isQueryPeer: true, replacementStrategy: .anyReplaceable).wait() == false
-        )
-        #expect(try routingTable.addPeer(peer2, isQueryPeer: true, replacementStrategy: .anyReplaceable).wait())
-        #expect(try routingTable.addPeer(peer3, isQueryPeer: true, replacementStrategy: .anyReplaceable).wait())
-        #expect(try routingTable.bucketCount.wait() == 4)
-        #expect(try routingTable.getPeerInfos().wait().count == 4)
-        print(routingTable)
-
-        /// Make sure we can find all of the peers
-        #expect(try routingTable.find(id: peer0).wait() != nil)
-        #expect(try routingTable.find(id: peer1).wait() != nil)
-        #expect(try routingTable.find(id: peer2).wait() != nil)
-        #expect(try routingTable.find(id: peer3).wait() != nil)
-        #expect(try routingTable.nearest(1, peersTo: peer0).wait().first?.id == peer0.id)
-        #expect(try routingTable.nearest(1, peersTo: peer1).wait().first?.id == peer1.id)
-        #expect(try routingTable.nearest(1, peersTo: peer2).wait().first?.id == peer2.id)
-        #expect(try routingTable.nearest(1, peersTo: peer3).wait().first?.id == peer3.id)
-
-        let nearbyPeers = try routingTable.nearest(4, peersTo: peer1).wait()
-        for dhtPeer in nearbyPeers { print(dhtPeer.id) }
-        #expect(nearbyPeers.count == 4)
-        #expect(nearbyPeers.contains(where: { $0.id == peer0.id }))
-        #expect(nearbyPeers.contains(where: { $0.id == peer1.id }))
-        #expect(nearbyPeers.contains(where: { $0.id == peer2.id }))
-        #expect(nearbyPeers.contains(where: { $0.id == peer3.id }))
-
-        /// Removing peer 1, 2 and 3 should result in only a single bucket
-        /// removing peer1 first results in an empty internal bucket without triggering a collapse
-        #expect(try routingTable.removePeer(peer1).wait())
-        /// 📒 --------------------------------- 📒
-        /// Routing Table [<peer.ID dJwpME>]
-        /// Bucket Count: 4 buckets of size: 1
-        /// Total Peers: 3
-        /// b[0] = [0]
-        /// b[1] = []
-        /// b[2] = [2]
-        /// b[3] = [3]
-        /// ---------------------------------------
-        /// removing peer2 next causes a cascading collapse that ends up 'removing' bucket 1 and 2
-        #expect(try routingTable.removePeer(peer2).wait())
-        /// 📒 --------------------------------- 📒
-        /// Routing Table [<peer.ID dJwpME>]
-        /// Bucket Count: 2 buckets of size: 1
-        /// Total Peers: 2
-        /// b[0] = [0]
-        /// b[1] = [3]
-        /// ---------------------------------------
-        /// removing peer3 from the last bucket also deletes it resulting in a single peer0 in bucket[0]
-        #expect(try routingTable.removePeer(peer3).wait())
-        /// 📒 --------------------------------- 📒
-        /// Routing Table [<peer.ID dJwpME>]
-        /// Bucket Count: 1 buckets of size: 1
-        /// Total Peers: 1
-        /// b[0] = [0]
-        /// ---------------------------------------
-        #expect(try routingTable.bucketCount.wait() == 1)
-        #expect(try routingTable.getPeerInfos().wait().count == 1)
-        #expect(try routingTable.getPeerInfos().wait().contains(where: { $0.id == peer0.id }))
-        print(routingTable)
-
-        /// Add back all four peers
-        #expect(
-            try routingTable.addPeer(peer0, isQueryPeer: true, replacementStrategy: .anyReplaceable).wait() == false
-        )
-        #expect(try routingTable.addPeer(peer1, isQueryPeer: true, replacementStrategy: .anyReplaceable).wait())
-        #expect(try routingTable.addPeer(peer2, isQueryPeer: true, replacementStrategy: .anyReplaceable).wait())
-        #expect(try routingTable.addPeer(peer3, isQueryPeer: true, replacementStrategy: .anyReplaceable).wait())
-        #expect(try routingTable.bucketCount.wait() == 4)
-        #expect(try routingTable.getPeerInfos().wait().count == 4)
-        print(routingTable)
-
-        /// Removing peer 1, causing an empty interior bucket, doesn't trigger a collapse (ew should still have 4 buckets) (see above for more info)
-        #expect(try routingTable.removePeer(peer1).wait())
-        #expect(try routingTable.bucketCount.wait() == 4)
-        #expect(try routingTable.getPeerInfos().wait().count == 3)
-        #expect(try routingTable.getPeerInfos().wait().contains(where: { $0.id == peer1.id }) == false)
-        print(routingTable)
-    }
-
-    @Test func testRemovePeer() throws {
-        let local = RandomDHTPeer()
-
-        print(local.id)
-        print(local.dhtID.bytes)
-
-        let elg = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        defer {
-            print("Shutting Down EventLoopGroup")
-            try! elg.syncShutdownGracefully()
+            #expect(routingTable.description.trimmingCharacters(in: .whitespacesAndNewlines) == desc)
+            try elg.syncShutdownGracefully()
         }
 
-        let routingTable = RoutingTable(
-            eventloop: elg.next(),
-            bucketSize: 2,
-            localPeerID: local.id,
-            latency: .hours(1),
-            peerstoreMetrics: [:],
-            usefulnessGracePeriod: .hours(1)
-        )
+        @Test func testBasicBucketFunctions() throws {
+            let peerCount = 100
+            var bucket = Bucket()
 
-        /// Generate random Peers
-        let peer0 = RandomDHTPeer()
-        let peer1 = RandomDHTPeer()
+            let local = try PeerID(.Ed25519)
+            let localID = KadDHT.Key(local)
 
-        /// Add the peers to the routing table
-        #expect(try routingTable.addPeer(peer0, isQueryPeer: true, replacementStrategy: .anyReplaceable).wait())
-        #expect(try routingTable.addPeer(peer1, isQueryPeer: true, replacementStrategy: .anyReplaceable).wait())
+            let time1 = Date().timeIntervalSince1970
+            let time2 = Date().timeIntervalSince1970 + 10
 
-        /// Ensure the peers were added
-        #expect(try routingTable.getPeerInfos().wait().contains(where: { $0.id == peer0.id }))
-        #expect(try routingTable.getPeerInfos().wait().contains(where: { $0.id == peer1.id }))
-        #expect(try routingTable.find(id: peer0).wait() != nil)
-        #expect(try routingTable.find(id: peer1).wait() != nil)
-        #expect(try routingTable.getPeerInfos().wait().count == 2)
-        #expect(try routingTable.bucketCount.wait() == 1)
+            let peers: [PeerID] = (0..<peerCount).map { _ in try! PeerID(.Ed25519) }
+            for peer in peers {
+                bucket.pushFront(
+                    DHTPeerInfo(
+                        id: peer,
+                        lastUsefulAt: time1,
+                        lastSuccessfulOutboundQueryAt: time2,
+                        addedAt: time1,
+                        dhtID: KadDHT.Key(peer),
+                        replaceable: false
+                    )
+                )
+            }
 
-        /// Remove a peer from the routing table
-        #expect(try routingTable.find(id: peer1).wait() != nil)
-        #expect(try routingTable.removePeer(peer1).wait())
-        #expect(try routingTable.find(id: peer1).wait() == nil)
-        #expect(try routingTable.getPeerInfos().wait().count == 1)
-        #expect(try routingTable.bucketCount.wait() == 1)
-        #expect(try routingTable.getPeerInfos().wait().contains(where: { $0.id == peer1.id }) == false)
-        #expect(try routingTable.getPeerInfos().wait().contains(where: { $0.id == peer0.id }))
-    }
+            /// Assert that all 100 peers were added to the bucket
+            #expect(bucket.peers().count == peerCount)
 
-    @Test func testTableCallbackClosures() throws {
-        let local = RandomDHTPeer()
+            /// Modifying a peer in a bucket via unsafeMutablePointer
+            let newTime2 = Date().timeIntervalSince1970 + 3600
+            let newTime3 = newTime2 + 3600
 
-        print(local.id)
-        print(local.dhtID.bytes)
+            /// Select a random peer and make sure it was instantiated correctly
+            let randomIndex = Int.random(in: 0..<peerCount)
+            bucket.getPeer(peers[randomIndex]) { randomPeer in
+                print("Running Modifier on \(randomPeer.id)")
+                #expect(peers[randomIndex] == randomPeer.id)
+                #expect(KadDHT.Key(peers[randomIndex]) == randomPeer.dhtID)
+                #expect(randomPeer.lastUsefulAt == time1)
+                #expect(randomPeer.lastSuccessfulOutboundQueryAt == time2)
 
-        let elg = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        defer {
-            print("Shutting Down EventLoopGroup")
-            try! elg.syncShutdownGracefully()
-        }
+                /// Modify the peer in place...
+                randomPeer.lastSuccessfulOutboundQueryAt = newTime2
+                randomPeer.lastUsefulAt = newTime3
+            }
 
-        let routingTable = RoutingTable(
-            eventloop: elg.next(),
-            bucketSize: 10,
-            localPeerID: local.id,
-            latency: .hours(1),
-            peerstoreMetrics: [:],
-            usefulnessGracePeriod: .hours(1)
-        )
-        routingTable.logLevel = .warning
+            /// Ensure our modification were realized
+            let randomPeer = bucket.getPeer(peers[randomIndex])
+            print("Checking Modification on \(randomPeer!.id)")
+            #expect(randomPeer?.lastSuccessfulOutboundQueryAt == newTime2)
+            #expect(randomPeer?.lastUsefulAt == newTime3)
 
-        var peersSet: [PeerID] = []
-        /// install our callback handlers
-        routingTable.peerAddedHandler = { peer in
-            print("Peer Added: \(peer)")
-            peersSet.append(peer)
-        }
-        routingTable.peerRemovedHandler = { peer in
-            print("Peer Removed: \(peer)")
-            peersSet.removeAll(where: { $0.id == peer.id })
-        }
+            let split = bucket.split(commonPrefixLength: 0, targetID: localID.bytes)
 
-        /// Generate random Peers
-        let peerCount = 100
-        let peers: [DHTPeerInfo] = (0..<peerCount).map { _ in RandomDHTPeer() }
+            print("Bucket Count Post Split: \(bucket.count)")
+            print("New Bucket (non 0 cpls) Count: \(split.count)")
 
-        /// Make sure our callbacks work...
-        #expect(try routingTable.addPeer(peers[0], isQueryPeer: true).wait())
-        #expect(peersSet.contains(peers[0].id))
-        if peersSet.count != 1 { Issue.record("Our peerAdded callback didn't work ") }
+            print(localID.bytes)
 
-        #expect(try routingTable.removePeer(peers[0]).wait())
-        #expect(peersSet.contains(peers[0].id) == false)
-        if peersSet.count != 0 { Issue.record("Our peerRemoved callback didn't work") }
-
-        /// Add all the peers!
-        let _ = try peers.map {
-            try routingTable.addPeer($0, isQueryPeer: true)
-        }.flatten(on: elg.next()).wait()
-
-        print(routingTable)
-
-        /// Check to make sure that each peer that was added to the routingTable was added to our peersSet array
-        let out = try routingTable.getPeerInfos().wait()
-        #expect(out.count == peersSet.count)
-        for peer in out {
-            #expect(peersSet.contains(peer.id))
-            #expect(try routingTable.removePeer(peer).wait())
-            /// removing the peer should trigger our peerRemovalHandler which will remove the peer from our peersSet array
-        }
-
-        /// Ensure both our peersSet and routingTable are empty after the peer removal
-        #expect(peersSet.count == 0)
-        #expect(try routingTable.getPeerInfos().wait().count == 0)
-    }
-
-    @Test func testAddLargeAmountOfPeersAndLoad() throws {
-        let local = RandomDHTPeer()
-
-        print(local.id)
-        print(local.dhtID.bytes)
-
-        let elg = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        defer {
-            print("Shutting Down EventLoopGroup")
-            try! elg.syncShutdownGracefully()
-        }
-
-        let routingTable = RoutingTable(
-            eventloop: elg.next(),
-            bucketSize: 20,
-            localPeerID: local.id,
-            latency: .hours(1),
-            peerstoreMetrics: [:],
-            usefulnessGracePeriod: .hours(1)
-        )
-        routingTable.logLevel = .warning
-
-        /// Generate random Peers
-        let peerCount = 500
-        let peers: [DHTPeerInfo] = (0..<peerCount).map { _ in RandomDHTPeer() }
-
-        /// Add random peers from the list
-        for _ in (0..<50000) {
-            guard let randPeer = peers.randomElement() else { continue }
-            #expect(throws: Never.self) { try routingTable.addPeer(randPeer, isQueryPeer: true).wait() }
-        }
-
-        print(routingTable)
-
-        for _ in (0..<100) {
-            let rp = RandomPeerID()
-            #expect(try routingTable.nearest(5, peersTo: rp).wait().count == 5)
-        }
-    }
-
-    @Test func testTableFind() throws {
-        let local = RandomDHTPeer()
-
-        print(local.id)
-        print(local.dhtID.bytes)
-
-        let elg = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        defer {
-            print("Shutting Down EventLoopGroup")
-            try! elg.syncShutdownGracefully()
-        }
-
-        let routingTable = RoutingTable(
-            eventloop: elg.next(),
-            bucketSize: 10,
-            localPeerID: local.id,
-            latency: .hours(1),
-            peerstoreMetrics: [:],
-            usefulnessGracePeriod: .hours(1)
-        )
-        routingTable.logLevel = .warning
-
-        /// Generate random Peers
-        let peerCount = 5
-        let peers: [DHTPeerInfo] = (0..<peerCount).map { _ in RandomDHTPeer() }
-
-        /// Add random peers from the list
-        for peer in peers {
-            #expect(throws: Never.self) { try routingTable.addPeer(peer, isQueryPeer: true).wait() }
-        }
-
-        print(routingTable)
-
-        for peer in peers {
-            #expect(try routingTable.getPeerInfos().wait().contains(where: { $0.id == peer.id }))
-            #expect(try routingTable.find(id: peer).wait() != nil)
-            //XCTAssertEqual(try routingTable.nearestPeer(to: peer).wait()!.dhtID, peer.dhtID)
-        }
-    }
-
-    @Test func testUpdateLastSuccessfulOutboundQueryAt() throws {
-        let local = RandomDHTPeer()
-
-        print(local.id)
-        print(local.dhtID.bytes)
-
-        let elg = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        defer {
-            print("Shutting Down EventLoopGroup")
-            try! elg.syncShutdownGracefully()
-        }
-
-        let routingTable = RoutingTable(
-            eventloop: elg.next(),
-            bucketSize: 10,
-            localPeerID: local.id,
-            latency: .hours(1),
-            peerstoreMetrics: [:],
-            usefulnessGracePeriod: .hours(1)
-        )
-        routingTable.logLevel = .warning
-
-        /// Generate a random peer and add them to the table
-        let peer = RandomDHTPeer()
-        let peer2 = RandomDHTPeer()
-        #expect(try routingTable.addPeer(peer, isQueryPeer: true).wait())
-        #expect(try routingTable.find(id: peer).wait()?.id == peer.id)
-
-        /// Update the last successful outbound query for the peer
-        let time = Date().timeIntervalSince1970 + 3600
-        #expect(try routingTable.updateLastSuccessfulOutboundQuery(at: time, for: peer.id).wait())
-        #expect(try routingTable.updateLastSuccessfulOutboundQuery(at: time, for: peer2).wait() == false)
-
-        /// Ensure the update stuck
-        #expect(try routingTable.find(id: peer).wait()?.lastSuccessfulOutboundQueryAt == time)
-
-        print(routingTable)
-
-        /// Now do it a bunch of times
-        for i in 0..<1000 {
-            let newTime = Date().timeIntervalSince1970.advanced(by: Double(i))
-            #expect(try routingTable.updateLastSuccessfulOutboundQuery(at: newTime, for: peer).wait())
-
-            if i % 10 == 0 {
-                #expect(try routingTable.find(id: peer).wait()?.lastSuccessfulOutboundQueryAt == newTime)
+            /// Bucket should be peers with a CPL == 0
+            for dhtPeer in bucket.peers() {
+                let cpl = local.commonPrefixLength(with: dhtPeer.id)
+                //print(dhtPeer.dhtID.bytes)
+                #expect(cpl == 0)
+            }
+            /// Split should contain only peers who's CPL > 0
+            for dhtPeer in split.peers() {
+                let cpl = local.commonPrefixLength(with: dhtPeer.id)
+                print(dhtPeer.dhtID.bytes)
+                #expect(cpl > 0)
             }
         }
-    }
 
-    @Test func testUpdateLastUsefulAt() throws {
-        let local = RandomDHTPeer()
+        @Test func testRandomDHTKeyCPL() throws {
+            let local = RandomDHTKey()
 
-        print(local.id)
-        print(local.dhtID.bytes)
+            let similar0 = RandomDHTKey(withCPL: 0, wrt: local)
+            #expect(local.commonPrefixLength(with: similar0) == 0)
 
-        let elg = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        defer {
-            print("Shutting Down EventLoopGroup")
-            try! elg.syncShutdownGracefully()
+            let similar1 = RandomDHTKey(withCPL: 1, wrt: local)
+            #expect(local.commonPrefixLength(with: similar1) == 1)
+
+            let similar2 = RandomDHTKey(withCPL: 2, wrt: local)
+            #expect(local.commonPrefixLength(with: similar2) == 2)
+
+            let similar3 = RandomDHTKey(withCPL: 3, wrt: local)
+            #expect(local.commonPrefixLength(with: similar3) == 3)
+
+            let similar4 = RandomDHTKey(withCPL: 4, wrt: local)
+            #expect(local.commonPrefixLength(with: similar4) == 4)
+
+            let similar5 = RandomDHTKey(withCPL: 5, wrt: local)
+            #expect(local.commonPrefixLength(with: similar5) == 5)
+
+            let similar6 = RandomDHTKey(withCPL: 6, wrt: local)
+            #expect(local.commonPrefixLength(with: similar6) == 6)
+
+            let similar7 = RandomDHTKey(withCPL: 7, wrt: local)
+            #expect(local.commonPrefixLength(with: similar7) == 7)
+
+            let similar8 = RandomDHTKey(withCPL: 8, wrt: local)
+            #expect(local.commonPrefixLength(with: similar8) == 8)
+
+            let similar9 = RandomDHTKey(withCPL: 9, wrt: local)
+            #expect(local.commonPrefixLength(with: similar9) == 9)
         }
 
-        let routingTable = RoutingTable(
-            eventloop: elg.next(),
-            bucketSize: 10,
-            localPeerID: local.id,
-            latency: .hours(1),
-            peerstoreMetrics: [:],
-            usefulnessGracePeriod: .hours(1)
-        )
-        routingTable.logLevel = .warning
+        /// - TODO: We're confusing DHTPeer and PeerIDs at the moment... We should update the Routing Table to handle DHTPeers instead of PeerID
+        @Test func testBucketGetPeersByCPL() throws {
+            let local = RandomDHTPeer()
 
-        /// Generate a random peer and add them to the table
-        let peer = RandomDHTPeer()
-        let peer2 = RandomDHTPeer()
-        #expect(try routingTable.addPeer(peer, isQueryPeer: true).wait())
-        #expect(try routingTable.find(id: peer).wait()?.id == peer.id)
+            print(local.id)
+            print(local.dhtID.bytes)
 
-        /// Update the last useful at time for the peer
-        let time = Date().timeIntervalSince1970 + 3600
-        #expect(try routingTable.updateLastUseful(at: time, for: peer).wait())
-        #expect(try routingTable.updateLastUseful(at: time, for: peer2).wait() == false)
+            let elg = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+            let routingTable = RoutingTable(
+                eventloop: elg.next(),
+                bucketSize: 2,
+                localPeerID: local.id,
+                latency: .hours(1),
+                peerstoreMetrics: [:],
+                usefulnessGracePeriod: .hours(1)
+            )
 
-        /// Ensure the update stuck
-        #expect(try routingTable.find(id: peer).wait()?.lastUsefulAt == time)
+            #expect(try 0 == routingTable.numberOfPeers(withCommonPrefixLength: 0).wait())
+            #expect(try 0 == routingTable.numberOfPeers(withCommonPrefixLength: 1).wait())
 
-        /// Now do it a bunch of times
-        for i in 0..<1000 {
-            let newTime = Date().timeIntervalSince1970.advanced(by: Double(i))
-            #expect(try routingTable.updateLastUseful(at: newTime, for: peer).wait())
+            /// Generate and add a peer with a commonPrefixLength of 1 w.r.t our local peer id
+            let peerCPL1 = RandomDHTPeer(withCPL: 1, wrt: local.dhtID)
+            #expect(
+                try routingTable.addPeer(peerCPL1, isQueryPeer: true, replacementStrategy: .anyReplaceable).wait()
+            )
+            print("Added peer: \(peerCPL1.dhtID.bytes)")
+            print(routingTable)
+            #expect(try 0 == routingTable.numberOfPeers(withCommonPrefixLength: 0).wait())
+            #expect(try 1 == routingTable.numberOfPeers(withCommonPrefixLength: 1).wait())
+            #expect(try 0 == routingTable.numberOfPeers(withCommonPrefixLength: 2).wait())
 
-            if i % 10 == 0 {
-                #expect(try routingTable.find(id: peer).wait()?.lastUsefulAt == newTime)
+            /// Generate and add a peer with a commonPrefixLength of 0 w.r.t our local peer id
+            let peerCPL0 = RandomDHTPeer(withCPL: 0, wrt: local.dhtID)
+            #expect(
+                try routingTable.addPeer(peerCPL0, isQueryPeer: true, replacementStrategy: .anyReplaceable).wait()
+            )
+            print("Added peer: \(peerCPL0.dhtID.bytes)")
+            print(routingTable)
+            #expect(try 1 == routingTable.numberOfPeers(withCommonPrefixLength: 0).wait())
+            #expect(try 1 == routingTable.numberOfPeers(withCommonPrefixLength: 1).wait())
+            #expect(try 0 == routingTable.numberOfPeers(withCommonPrefixLength: 2).wait())
+
+            /// Generate and add a peer with a commonPrefixLength of 1 w.r.t our local peer id
+            /// Adding a third peer will force a bucket split when our bucketSize param is set to 2
+            let peerCPL1_2 = RandomDHTPeer(withCPL: 1, wrt: local.dhtID)
+            #expect(
+                try routingTable.addPeer(peerCPL1_2, isQueryPeer: true, replacementStrategy: .anyReplaceable).wait()
+            )
+            print("Added peer: \(peerCPL1_2.dhtID.bytes)")
+            print(routingTable)
+            #expect(try 1 == routingTable.numberOfPeers(withCommonPrefixLength: 0).wait())
+            #expect(try 2 == routingTable.numberOfPeers(withCommonPrefixLength: 1).wait())
+            #expect(try 0 == routingTable.numberOfPeers(withCommonPrefixLength: 2).wait())
+
+            /// Generate and add a peer with a commonPrefixLength of 0 w.r.t our local peer id
+            let peerCPL0_2 = RandomDHTPeer(withCPL: 0, wrt: local.dhtID)
+            #expect(
+                try routingTable.addPeer(peerCPL0_2, isQueryPeer: true, replacementStrategy: .anyReplaceable).wait()
+            )
+            print("Added peer: \(peerCPL0_2.dhtID.bytes)")
+            print(routingTable)
+            #expect(try 2 == routingTable.numberOfPeers(withCommonPrefixLength: 0).wait())
+            #expect(try 2 == routingTable.numberOfPeers(withCommonPrefixLength: 1).wait())
+            #expect(try 0 == routingTable.numberOfPeers(withCommonPrefixLength: 2).wait())
+
+            /// Generate and add a peer with a commonPrefixLength of 1 w.r.t our local peer id
+            /// Attempting to add a third peer with a CPL of 1 will force a bucket split but will fail to add the peer due to the bucket for CPL 1's being full
+            /// And the fact that all of the peers added so far have their replaceable param set to false
+            let peerCPL1_3 = RandomDHTPeer(withCPL: 1, wrt: local.dhtID)
+            #expect(
+                try routingTable.addPeer(peerCPL1_3, isQueryPeer: true, replacementStrategy: .anyReplaceable).wait()
+                    == false
+            )
+            print(routingTable)
+
+            /// Attempting Again Fails
+            let peerCPL1_4 = RandomDHTPeer(withCPL: 1, wrt: local.dhtID)
+            #expect(
+                try routingTable.addPeer(peerCPL1_4, isQueryPeer: true, replacementStrategy: .anyReplaceable).wait()
+                    == false
+            )
+            print(routingTable)
+
+            /// Generate and add a peer with a commonPrefixLength of 2 w.r.t our local peer id
+            /// Adding this peer should succeed due to having excess capacity in bucket[2]
+            let peerCPL2_1 = RandomDHTPeer(withCPL: 2, wrt: local.dhtID)
+            #expect(
+                try routingTable.addPeer(peerCPL2_1, isQueryPeer: true, replacementStrategy: .anyReplaceable).wait()
+            )
+            print("Added peer: \(peerCPL2_1.dhtID.bytes)")
+            print(routingTable)
+            #expect(try 2 == routingTable.numberOfPeers(withCommonPrefixLength: 0).wait())
+            #expect(try 2 == routingTable.numberOfPeers(withCommonPrefixLength: 1).wait())
+            #expect(try 1 == routingTable.numberOfPeers(withCommonPrefixLength: 2).wait())
+
+            /// TODO: Mark a peer as replaceable and attempt to add a peer in it's place
+
+            try elg.syncShutdownGracefully()
+        }
+
+        @Test func testEmptyBucketCollapse() throws {
+
+            let local = RandomDHTPeer()
+
+            print(local.id)
+            print(local.dhtID.bytes)
+
+            let elg = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+            defer { try! elg.syncShutdownGracefully() }
+
+            let routingTable = RoutingTable(
+                eventloop: elg.next(),
+                bucketSize: 1,
+                localPeerID: local.id,
+                latency: .hours(1),
+                peerstoreMetrics: [:],
+                usefulnessGracePeriod: .hours(1)
+            )
+            routingTable.logLevel = .debug
+
+            /// Generate Peers with CPLs of 0, 1, 2 and 3
+            let peer0 = RandomDHTPeer(withCPL: 0, wrt: local.dhtID)
+            let peer1 = RandomDHTPeer(withCPL: 1, wrt: local.dhtID)
+            let peer2 = RandomDHTPeer(withCPL: 2, wrt: local.dhtID)
+            let peer3 = RandomDHTPeer(withCPL: 3, wrt: local.dhtID)
+
+            /// Removing a peer on an empty bucket shouldn't throw an error
+            #expect(throws: Never.self) { try routingTable.removePeer(peer0).wait() }
+
+            /// Add and then remove peer0, this should create a bucket[0]
+            #expect(try routingTable.addPeer(peer0, isQueryPeer: true, replacementStrategy: .anyReplaceable).wait())
+            /// Removing the peer from the bucket shouldn't cause the bucket to disappear due to it being the only bucket we have
+            #expect(try routingTable.removePeer(peer0).wait())
+            #expect(try routingTable.bucketCount.wait() == 1)
+            #expect(try routingTable.getPeerInfos().wait().count == 0)
+            print(routingTable)
+
+            /// Add peer with CPL 0 and 1 and verify that our RoutingTable has 2 buckets
+            #expect(try routingTable.addPeer(peer0, isQueryPeer: true, replacementStrategy: .anyReplaceable).wait())
+            #expect(try routingTable.addPeer(peer1, isQueryPeer: true, replacementStrategy: .anyReplaceable).wait())
+            #expect(try routingTable.bucketCount.wait() == 2)
+            #expect(try routingTable.getPeerInfos().wait().count == 2)
+            print(routingTable)
+
+            /// Removing a peer from the last bucket should cause it to collapse
+            #expect(try routingTable.removePeer(peer1).wait())
+            #expect(try routingTable.bucketCount.wait() == 1)
+            #expect(try routingTable.getPeerInfos().wait().count == 1)
+            #expect(try routingTable.getPeerInfos().wait().contains(where: { $0.id == peer0.id }))
+            //print(try routingTable.getPeerInfos().wait())
+            print(routingTable)
+
+            /// Add peer with CPL 1 again and verify that our RoutingTable has 2 buckets
+            #expect(try routingTable.addPeer(peer1, isQueryPeer: true, replacementStrategy: .anyReplaceable).wait())
+            #expect(try routingTable.bucketCount.wait() == 2)
+            #expect(try routingTable.getPeerInfos().wait().count == 2)
+            print(routingTable)
+
+            /// Remove a peer from the second to last bucket (the first bucket in this case) and ensure it collapses as expected
+            #expect(try routingTable.removePeer(peer0).wait())
+            #expect(try routingTable.bucketCount.wait() == 1)
+            #expect(try routingTable.getPeerInfos().wait().count == 1)
+            #expect(try routingTable.getPeerInfos().wait().contains(where: { $0.id == peer1.id }))
+            print(routingTable)
+
+            /// Add all four peers and expect 4 buckets (peer1 shouldn't be added twice)
+            #expect(try routingTable.addPeer(peer0, isQueryPeer: true, replacementStrategy: .anyReplaceable).wait())
+            #expect(
+                try routingTable.addPeer(peer1, isQueryPeer: true, replacementStrategy: .anyReplaceable).wait() == false
+            )
+            #expect(try routingTable.addPeer(peer2, isQueryPeer: true, replacementStrategy: .anyReplaceable).wait())
+            #expect(try routingTable.addPeer(peer3, isQueryPeer: true, replacementStrategy: .anyReplaceable).wait())
+            #expect(try routingTable.bucketCount.wait() == 4)
+            #expect(try routingTable.getPeerInfos().wait().count == 4)
+            print(routingTable)
+
+            /// Make sure we can find all of the peers
+            #expect(try routingTable.find(id: peer0).wait() != nil)
+            #expect(try routingTable.find(id: peer1).wait() != nil)
+            #expect(try routingTable.find(id: peer2).wait() != nil)
+            #expect(try routingTable.find(id: peer3).wait() != nil)
+            #expect(try routingTable.nearest(1, peersTo: peer0).wait().first?.id == peer0.id)
+            #expect(try routingTable.nearest(1, peersTo: peer1).wait().first?.id == peer1.id)
+            #expect(try routingTable.nearest(1, peersTo: peer2).wait().first?.id == peer2.id)
+            #expect(try routingTable.nearest(1, peersTo: peer3).wait().first?.id == peer3.id)
+
+            let nearbyPeers = try routingTable.nearest(4, peersTo: peer1).wait()
+            for dhtPeer in nearbyPeers { print(dhtPeer.id) }
+            #expect(nearbyPeers.count == 4)
+            #expect(nearbyPeers.contains(where: { $0.id == peer0.id }))
+            #expect(nearbyPeers.contains(where: { $0.id == peer1.id }))
+            #expect(nearbyPeers.contains(where: { $0.id == peer2.id }))
+            #expect(nearbyPeers.contains(where: { $0.id == peer3.id }))
+
+            /// Removing peer 1, 2 and 3 should result in only a single bucket
+            /// removing peer1 first results in an empty internal bucket without triggering a collapse
+            #expect(try routingTable.removePeer(peer1).wait())
+            /// 📒 --------------------------------- 📒
+            /// Routing Table [<peer.ID dJwpME>]
+            /// Bucket Count: 4 buckets of size: 1
+            /// Total Peers: 3
+            /// b[0] = [0]
+            /// b[1] = []
+            /// b[2] = [2]
+            /// b[3] = [3]
+            /// ---------------------------------------
+            /// removing peer2 next causes a cascading collapse that ends up 'removing' bucket 1 and 2
+            #expect(try routingTable.removePeer(peer2).wait())
+            /// 📒 --------------------------------- 📒
+            /// Routing Table [<peer.ID dJwpME>]
+            /// Bucket Count: 2 buckets of size: 1
+            /// Total Peers: 2
+            /// b[0] = [0]
+            /// b[1] = [3]
+            /// ---------------------------------------
+            /// removing peer3 from the last bucket also deletes it resulting in a single peer0 in bucket[0]
+            #expect(try routingTable.removePeer(peer3).wait())
+            /// 📒 --------------------------------- 📒
+            /// Routing Table [<peer.ID dJwpME>]
+            /// Bucket Count: 1 buckets of size: 1
+            /// Total Peers: 1
+            /// b[0] = [0]
+            /// ---------------------------------------
+            #expect(try routingTable.bucketCount.wait() == 1)
+            #expect(try routingTable.getPeerInfos().wait().count == 1)
+            #expect(try routingTable.getPeerInfos().wait().contains(where: { $0.id == peer0.id }))
+            print(routingTable)
+
+            /// Add back all four peers
+            #expect(
+                try routingTable.addPeer(peer0, isQueryPeer: true, replacementStrategy: .anyReplaceable).wait() == false
+            )
+            #expect(try routingTable.addPeer(peer1, isQueryPeer: true, replacementStrategy: .anyReplaceable).wait())
+            #expect(try routingTable.addPeer(peer2, isQueryPeer: true, replacementStrategy: .anyReplaceable).wait())
+            #expect(try routingTable.addPeer(peer3, isQueryPeer: true, replacementStrategy: .anyReplaceable).wait())
+            #expect(try routingTable.bucketCount.wait() == 4)
+            #expect(try routingTable.getPeerInfos().wait().count == 4)
+            print(routingTable)
+
+            /// Removing peer 1, causing an empty interior bucket, doesn't trigger a collapse (ew should still have 4 buckets) (see above for more info)
+            #expect(try routingTable.removePeer(peer1).wait())
+            #expect(try routingTable.bucketCount.wait() == 4)
+            #expect(try routingTable.getPeerInfos().wait().count == 3)
+            #expect(try routingTable.getPeerInfos().wait().contains(where: { $0.id == peer1.id }) == false)
+            print(routingTable)
+        }
+
+        @Test func testRemovePeer() throws {
+            let local = RandomDHTPeer()
+
+            print(local.id)
+            print(local.dhtID.bytes)
+
+            let elg = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+            defer {
+                print("Shutting Down EventLoopGroup")
+                try! elg.syncShutdownGracefully()
+            }
+
+            let routingTable = RoutingTable(
+                eventloop: elg.next(),
+                bucketSize: 2,
+                localPeerID: local.id,
+                latency: .hours(1),
+                peerstoreMetrics: [:],
+                usefulnessGracePeriod: .hours(1)
+            )
+
+            /// Generate random Peers
+            let peer0 = RandomDHTPeer()
+            let peer1 = RandomDHTPeer()
+
+            /// Add the peers to the routing table
+            #expect(try routingTable.addPeer(peer0, isQueryPeer: true, replacementStrategy: .anyReplaceable).wait())
+            #expect(try routingTable.addPeer(peer1, isQueryPeer: true, replacementStrategy: .anyReplaceable).wait())
+
+            /// Ensure the peers were added
+            #expect(try routingTable.getPeerInfos().wait().contains(where: { $0.id == peer0.id }))
+            #expect(try routingTable.getPeerInfos().wait().contains(where: { $0.id == peer1.id }))
+            #expect(try routingTable.find(id: peer0).wait() != nil)
+            #expect(try routingTable.find(id: peer1).wait() != nil)
+            #expect(try routingTable.getPeerInfos().wait().count == 2)
+            #expect(try routingTable.bucketCount.wait() == 1)
+
+            /// Remove a peer from the routing table
+            #expect(try routingTable.find(id: peer1).wait() != nil)
+            #expect(try routingTable.removePeer(peer1).wait())
+            #expect(try routingTable.find(id: peer1).wait() == nil)
+            #expect(try routingTable.getPeerInfos().wait().count == 1)
+            #expect(try routingTable.bucketCount.wait() == 1)
+            #expect(try routingTable.getPeerInfos().wait().contains(where: { $0.id == peer1.id }) == false)
+            #expect(try routingTable.getPeerInfos().wait().contains(where: { $0.id == peer0.id }))
+        }
+
+        @Test func testTableCallbackClosures() throws {
+            let local = RandomDHTPeer()
+
+            print(local.id)
+            print(local.dhtID.bytes)
+
+            let elg = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+            defer {
+                print("Shutting Down EventLoopGroup")
+                try! elg.syncShutdownGracefully()
+            }
+
+            let routingTable = RoutingTable(
+                eventloop: elg.next(),
+                bucketSize: 10,
+                localPeerID: local.id,
+                latency: .hours(1),
+                peerstoreMetrics: [:],
+                usefulnessGracePeriod: .hours(1)
+            )
+            routingTable.logLevel = .warning
+
+            var peersSet: [PeerID] = []
+            /// install our callback handlers
+            routingTable.peerAddedHandler = { peer in
+                print("Peer Added: \(peer)")
+                peersSet.append(peer)
+            }
+            routingTable.peerRemovedHandler = { peer in
+                print("Peer Removed: \(peer)")
+                peersSet.removeAll(where: { $0.id == peer.id })
+            }
+
+            /// Generate random Peers
+            let peerCount = 100
+            let peers: [DHTPeerInfo] = (0..<peerCount).map { _ in RandomDHTPeer() }
+
+            /// Make sure our callbacks work...
+            #expect(try routingTable.addPeer(peers[0], isQueryPeer: true).wait())
+            #expect(peersSet.contains(peers[0].id))
+            if peersSet.count != 1 { Issue.record("Our peerAdded callback didn't work ") }
+
+            #expect(try routingTable.removePeer(peers[0]).wait())
+            #expect(peersSet.contains(peers[0].id) == false)
+            if peersSet.count != 0 { Issue.record("Our peerRemoved callback didn't work") }
+
+            /// Add all the peers!
+            let _ = try peers.map {
+                try routingTable.addPeer($0, isQueryPeer: true)
+            }.flatten(on: elg.next()).wait()
+
+            print(routingTable)
+
+            /// Check to make sure that each peer that was added to the routingTable was added to our peersSet array
+            let out = try routingTable.getPeerInfos().wait()
+            #expect(out.count == peersSet.count)
+            for peer in out {
+                #expect(peersSet.contains(peer.id))
+                #expect(try routingTable.removePeer(peer).wait())
+                /// removing the peer should trigger our peerRemovalHandler which will remove the peer from our peersSet array
+            }
+
+            /// Ensure both our peersSet and routingTable are empty after the peer removal
+            #expect(peersSet.count == 0)
+            #expect(try routingTable.getPeerInfos().wait().count == 0)
+        }
+
+        @Test func testAddLargeAmountOfPeersAndLoad() throws {
+            let local = RandomDHTPeer()
+
+            print(local.id)
+            print(local.dhtID.bytes)
+
+            let elg = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+            defer {
+                print("Shutting Down EventLoopGroup")
+                try! elg.syncShutdownGracefully()
+            }
+
+            let routingTable = RoutingTable(
+                eventloop: elg.next(),
+                bucketSize: 20,
+                localPeerID: local.id,
+                latency: .hours(1),
+                peerstoreMetrics: [:],
+                usefulnessGracePeriod: .hours(1)
+            )
+            routingTable.logLevel = .warning
+
+            /// Generate random Peers
+            let peerCount = 500
+            let peers: [DHTPeerInfo] = (0..<peerCount).map { _ in RandomDHTPeer() }
+
+            /// Add random peers from the list
+            for _ in (0..<50000) {
+                guard let randPeer = peers.randomElement() else { continue }
+                #expect(throws: Never.self) { try routingTable.addPeer(randPeer, isQueryPeer: true).wait() }
+            }
+
+            print(routingTable)
+
+            for _ in (0..<100) {
+                let rp = RandomPeerID()
+                #expect(try routingTable.nearest(5, peersTo: rp).wait().count == 5)
             }
         }
-    }
 
-    @Test func testAddReplaceableAndNonQueryPeers() throws {
-        let local = RandomDHTPeer()
+        @Test func testTableFind() throws {
+            let local = RandomDHTPeer()
 
-        print(local.id)
-        print(local.dhtID.bytes)
+            print(local.id)
+            print(local.dhtID.bytes)
 
-        let elg = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        defer {
-            print("Shutting Down EventLoopGroup")
-            try! elg.syncShutdownGracefully()
+            let elg = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+            defer {
+                print("Shutting Down EventLoopGroup")
+                try! elg.syncShutdownGracefully()
+            }
+
+            let routingTable = RoutingTable(
+                eventloop: elg.next(),
+                bucketSize: 10,
+                localPeerID: local.id,
+                latency: .hours(1),
+                peerstoreMetrics: [:],
+                usefulnessGracePeriod: .hours(1)
+            )
+            routingTable.logLevel = .warning
+
+            /// Generate random Peers
+            let peerCount = 5
+            let peers: [DHTPeerInfo] = (0..<peerCount).map { _ in RandomDHTPeer() }
+
+            /// Add random peers from the list
+            for peer in peers {
+                #expect(throws: Never.self) { try routingTable.addPeer(peer, isQueryPeer: true).wait() }
+            }
+
+            print(routingTable)
+
+            for peer in peers {
+                #expect(try routingTable.getPeerInfos().wait().contains(where: { $0.id == peer.id }))
+                #expect(try routingTable.find(id: peer).wait() != nil)
+                //XCTAssertEqual(try routingTable.nearestPeer(to: peer).wait()!.dhtID, peer.dhtID)
+            }
         }
 
-        let routingTable = RoutingTable(
-            eventloop: elg.next(),
-            bucketSize: 2,
-            localPeerID: local.id,
-            latency: .hours(1),
-            peerstoreMetrics: [:],
-            usefulnessGracePeriod: .hours(1)
-        )
-        routingTable.logLevel = .trace
+        @Test func testUpdateLastSuccessfulOutboundQueryAt() throws {
+            let local = RandomDHTPeer()
 
-        /// Generate and Add two peers to saturate the first bucket
-        let peer1 = RandomDHTPeer(withCPL: 0, wrt: local.dhtID, isReplaceable: false)
-        let peer2 = RandomDHTPeer(withCPL: 0, wrt: local.dhtID, isReplaceable: true)
-        #expect(try routingTable.addPeer(peer1, isQueryPeer: true, replacementStrategy: .anyReplaceable).wait())
-        #expect(try routingTable.addPeer(peer2, isQueryPeer: true, replacementStrategy: .anyReplaceable).wait())
-        #expect(try routingTable.bucketCount.wait() == 1)
-        #expect(try routingTable.getPeerInfos().wait().count == 2)
-        #expect(try routingTable.find(id: peer1).wait()?.id == peer1.id)
-        #expect(try routingTable.find(id: peer2).wait()?.id == peer2.id)
-        print(routingTable)
+            print(local.id)
+            print(local.dhtID.bytes)
 
-        /// Generate a third peer and attempt to add to table, this should work because peer2 is replaceable
-        let peer3 = RandomDHTPeer(withCPL: 0, wrt: local.dhtID, isReplaceable: false)
-        #expect(try routingTable.addPeer(peer3, isQueryPeer: true, replacementStrategy: .anyReplaceable).wait())
-        #expect(try routingTable.getPeerInfos().wait().count == 2)
-        #expect(try routingTable.find(id: peer1).wait()?.id == peer1.id)
-        #expect(try routingTable.find(id: peer3).wait()?.id == peer3.id)
-        #expect(try routingTable.find(id: peer2).wait() == nil)
-        #expect(try routingTable.bucketCount.wait() == 1)
-        print(routingTable)
+            let elg = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+            defer {
+                print("Shutting Down EventLoopGroup")
+                try! elg.syncShutdownGracefully()
+            }
 
-        /// Generate a fourth peer with CPL = 0 and attempt to add to table, this should fail due to max number of CPL = 0 peers, and no replaceable peer
-        let peer4 = RandomDHTPeer(withCPL: 0, wrt: local.dhtID, isReplaceable: false)
-        #expect(
-            try routingTable.addPeer(peer4, isQueryPeer: true, replacementStrategy: .anyReplaceable).wait() == false
-        )
-        #expect(try routingTable.getPeerInfos().wait().count == 2)
-        #expect(try routingTable.find(id: peer1).wait()?.id == peer1.id)
-        #expect(try routingTable.find(id: peer3).wait()?.id == peer3.id)
-        #expect(try routingTable.find(id: peer4).wait() == nil)
-        // The attempt to add another CPL = 0 Peer results in a nextBucket operation being invoked,
-        // so we should have 2 buckets, the last one being empty...
-        #expect(try routingTable.bucketCount.wait() == 2)
-        print(routingTable)
+            let routingTable = RoutingTable(
+                eventloop: elg.next(),
+                bucketSize: 10,
+                localPeerID: local.id,
+                latency: .hours(1),
+                peerstoreMetrics: [:],
+                usefulnessGracePeriod: .hours(1)
+            )
+            routingTable.logLevel = .warning
 
-        /// Generate a fifth peer with CPL = 1 and attempt to add to table, this should succeed because we have excess capcity for peers with CPL = 1 (2 slots available at the moment)
-        let peer5 = RandomDHTPeer(withCPL: 1, wrt: local.dhtID, isReplaceable: false)
-        #expect(try routingTable.addPeer(peer5, isQueryPeer: true, replacementStrategy: .anyReplaceable).wait())
-        #expect(try routingTable.getPeerInfos().wait().count == 3)
-        #expect(try routingTable.find(id: peer1).wait()?.id == peer1.id)
-        #expect(try routingTable.find(id: peer3).wait()?.id == peer3.id)
-        #expect(try routingTable.find(id: peer5).wait()?.id == peer5.id)
-        #expect(try routingTable.bucketCount.wait() == 2)
-        print(routingTable)
+            /// Generate a random peer and add them to the table
+            let peer = RandomDHTPeer()
+            let peer2 = RandomDHTPeer()
+            #expect(try routingTable.addPeer(peer, isQueryPeer: true).wait())
+            #expect(try routingTable.find(id: peer).wait()?.id == peer.id)
 
-        /// Generate a sixth peer with CPL = 3 and isQueryPeer = false and attempt to add to table, this should work
-        let peer6 = RandomDHTPeer(withCPL: 3, wrt: local.dhtID, isReplaceable: false)
-        #expect(try routingTable.addPeer(peer6, isQueryPeer: false, replacementStrategy: .anyReplaceable).wait())
-        #expect(try routingTable.getPeerInfos().wait().count == 4)
-        #expect(try routingTable.find(id: peer1).wait()?.id == peer1.id)
-        #expect(try routingTable.find(id: peer3).wait()?.id == peer3.id)
-        #expect(try routingTable.find(id: peer5).wait()?.id == peer5.id)
-        #expect(try routingTable.find(id: peer6).wait()?.id == peer6.id)
-        #expect(try routingTable.find(id: peer6).wait()?.lastUsefulAt == nil)
-        #expect(try routingTable.bucketCount.wait() == 2)
-        print(routingTable)
-    }
+            /// Update the last successful outbound query for the peer
+            let time = Date().timeIntervalSince1970 + 3600
+            #expect(try routingTable.updateLastSuccessfulOutboundQuery(at: time, for: peer.id).wait())
+            #expect(try routingTable.updateLastSuccessfulOutboundQuery(at: time, for: peer2).wait() == false)
 
-    @Test func testMarkAllPeersIrreplaceable() throws {
-        let local = RandomDHTPeer()
+            /// Ensure the update stuck
+            #expect(try routingTable.find(id: peer).wait()?.lastSuccessfulOutboundQueryAt == time)
 
-        print(local.id)
-        print(local.dhtID.bytes)
+            print(routingTable)
 
-        let elg = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        defer {
-            print("Shutting Down EventLoopGroup")
-            try! elg.syncShutdownGracefully()
+            /// Now do it a bunch of times
+            for i in 0..<1000 {
+                let newTime = Date().timeIntervalSince1970.advanced(by: Double(i))
+                #expect(try routingTable.updateLastSuccessfulOutboundQuery(at: newTime, for: peer).wait())
+
+                if i % 10 == 0 {
+                    #expect(try routingTable.find(id: peer).wait()?.lastSuccessfulOutboundQueryAt == newTime)
+                }
+            }
         }
 
-        let bucketSize: Int = 20
-        let routingTable = RoutingTable(
-            eventloop: elg.next(),
-            bucketSize: bucketSize,
-            localPeerID: local.id,
-            latency: .hours(1),
-            peerstoreMetrics: [:],
-            usefulnessGracePeriod: .hours(1)
-        )
-        routingTable.logLevel = .warning
+        @Test func testUpdateLastUsefulAt() throws {
+            let local = RandomDHTPeer()
 
-        let peerCount = 50
-        let peers = (0..<peerCount).map { _ in
-            RandomDHTPeer(withCPL: Int.random(in: 0...8), wrt: local.dhtID, isReplaceable: true)
+            print(local.id)
+            print(local.dhtID.bytes)
+
+            let elg = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+            defer {
+                print("Shutting Down EventLoopGroup")
+                try! elg.syncShutdownGracefully()
+            }
+
+            let routingTable = RoutingTable(
+                eventloop: elg.next(),
+                bucketSize: 10,
+                localPeerID: local.id,
+                latency: .hours(1),
+                peerstoreMetrics: [:],
+                usefulnessGracePeriod: .hours(1)
+            )
+            routingTable.logLevel = .warning
+
+            /// Generate a random peer and add them to the table
+            let peer = RandomDHTPeer()
+            let peer2 = RandomDHTPeer()
+            #expect(try routingTable.addPeer(peer, isQueryPeer: true).wait())
+            #expect(try routingTable.find(id: peer).wait()?.id == peer.id)
+
+            /// Update the last useful at time for the peer
+            let time = Date().timeIntervalSince1970 + 3600
+            #expect(try routingTable.updateLastUseful(at: time, for: peer).wait())
+            #expect(try routingTable.updateLastUseful(at: time, for: peer2).wait() == false)
+
+            /// Ensure the update stuck
+            #expect(try routingTable.find(id: peer).wait()?.lastUsefulAt == time)
+
+            /// Now do it a bunch of times
+            for i in 0..<1000 {
+                let newTime = Date().timeIntervalSince1970.advanced(by: Double(i))
+                #expect(try routingTable.updateLastUseful(at: newTime, for: peer).wait())
+
+                if i % 10 == 0 {
+                    #expect(try routingTable.find(id: peer).wait()?.lastUsefulAt == newTime)
+                }
+            }
         }
 
-        for peer in peers {
-            #expect(throws: Never.self) { try routingTable.addPeer(peer, isQueryPeer: true).wait() }
+        @Test func testAddReplaceableAndNonQueryPeers() throws {
+            let local = RandomDHTPeer()
+
+            print(local.id)
+            print(local.dhtID.bytes)
+
+            let elg = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+            defer {
+                print("Shutting Down EventLoopGroup")
+                try! elg.syncShutdownGracefully()
+            }
+
+            let routingTable = RoutingTable(
+                eventloop: elg.next(),
+                bucketSize: 2,
+                localPeerID: local.id,
+                latency: .hours(1),
+                peerstoreMetrics: [:],
+                usefulnessGracePeriod: .hours(1)
+            )
+            routingTable.logLevel = .trace
+
+            /// Generate and Add two peers to saturate the first bucket
+            let peer1 = RandomDHTPeer(withCPL: 0, wrt: local.dhtID, isReplaceable: false)
+            let peer2 = RandomDHTPeer(withCPL: 0, wrt: local.dhtID, isReplaceable: true)
+            #expect(try routingTable.addPeer(peer1, isQueryPeer: true, replacementStrategy: .anyReplaceable).wait())
+            #expect(try routingTable.addPeer(peer2, isQueryPeer: true, replacementStrategy: .anyReplaceable).wait())
+            #expect(try routingTable.bucketCount.wait() == 1)
+            #expect(try routingTable.getPeerInfos().wait().count == 2)
+            #expect(try routingTable.find(id: peer1).wait()?.id == peer1.id)
+            #expect(try routingTable.find(id: peer2).wait()?.id == peer2.id)
+            print(routingTable)
+
+            /// Generate a third peer and attempt to add to table, this should work because peer2 is replaceable
+            let peer3 = RandomDHTPeer(withCPL: 0, wrt: local.dhtID, isReplaceable: false)
+            #expect(try routingTable.addPeer(peer3, isQueryPeer: true, replacementStrategy: .anyReplaceable).wait())
+            #expect(try routingTable.getPeerInfos().wait().count == 2)
+            #expect(try routingTable.find(id: peer1).wait()?.id == peer1.id)
+            #expect(try routingTable.find(id: peer3).wait()?.id == peer3.id)
+            #expect(try routingTable.find(id: peer2).wait() == nil)
+            #expect(try routingTable.bucketCount.wait() == 1)
+            print(routingTable)
+
+            /// Generate a fourth peer with CPL = 0 and attempt to add to table, this should fail due to max number of CPL = 0 peers, and no replaceable peer
+            let peer4 = RandomDHTPeer(withCPL: 0, wrt: local.dhtID, isReplaceable: false)
+            #expect(
+                try routingTable.addPeer(peer4, isQueryPeer: true, replacementStrategy: .anyReplaceable).wait() == false
+            )
+            #expect(try routingTable.getPeerInfos().wait().count == 2)
+            #expect(try routingTable.find(id: peer1).wait()?.id == peer1.id)
+            #expect(try routingTable.find(id: peer3).wait()?.id == peer3.id)
+            #expect(try routingTable.find(id: peer4).wait() == nil)
+            // The attempt to add another CPL = 0 Peer results in a nextBucket operation being invoked,
+            // so we should have 2 buckets, the last one being empty...
+            #expect(try routingTable.bucketCount.wait() == 2)
+            print(routingTable)
+
+            /// Generate a fifth peer with CPL = 1 and attempt to add to table, this should succeed because we have excess capcity for peers with CPL = 1 (2 slots available at the moment)
+            let peer5 = RandomDHTPeer(withCPL: 1, wrt: local.dhtID, isReplaceable: false)
+            #expect(try routingTable.addPeer(peer5, isQueryPeer: true, replacementStrategy: .anyReplaceable).wait())
+            #expect(try routingTable.getPeerInfos().wait().count == 3)
+            #expect(try routingTable.find(id: peer1).wait()?.id == peer1.id)
+            #expect(try routingTable.find(id: peer3).wait()?.id == peer3.id)
+            #expect(try routingTable.find(id: peer5).wait()?.id == peer5.id)
+            #expect(try routingTable.bucketCount.wait() == 2)
+            print(routingTable)
+
+            /// Generate a sixth peer with CPL = 3 and isQueryPeer = false and attempt to add to table, this should work
+            let peer6 = RandomDHTPeer(withCPL: 3, wrt: local.dhtID, isReplaceable: false)
+            #expect(try routingTable.addPeer(peer6, isQueryPeer: false, replacementStrategy: .anyReplaceable).wait())
+            #expect(try routingTable.getPeerInfos().wait().count == 4)
+            #expect(try routingTable.find(id: peer1).wait()?.id == peer1.id)
+            #expect(try routingTable.find(id: peer3).wait()?.id == peer3.id)
+            #expect(try routingTable.find(id: peer5).wait()?.id == peer5.id)
+            #expect(try routingTable.find(id: peer6).wait()?.id == peer6.id)
+            #expect(try routingTable.find(id: peer6).wait()?.lastUsefulAt == nil)
+            #expect(try routingTable.bucketCount.wait() == 2)
+            print(routingTable)
         }
 
-        print(routingTable)
+        @Test func testMarkAllPeersIrreplaceable() throws {
+            let local = RandomDHTPeer()
 
-        /// Get a list of all the peers that made it into our table
-        let peerInfos = try routingTable.getPeerInfos().wait()
-        #expect(peerInfos.count >= min(bucketSize, peerCount))
-        #expect(peerInfos.count >= 1)
+            print(local.id)
+            print(local.dhtID.bytes)
 
-        /// Ensure all the peers in the table are still marked as replaceable
-        for pi in peerInfos {
-            #expect(try routingTable.find(id: pi).wait()?.replaceable == true)
+            let elg = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+            defer {
+                print("Shutting Down EventLoopGroup")
+                try! elg.syncShutdownGracefully()
+            }
+
+            let bucketSize: Int = 20
+            let routingTable = RoutingTable(
+                eventloop: elg.next(),
+                bucketSize: bucketSize,
+                localPeerID: local.id,
+                latency: .hours(1),
+                peerstoreMetrics: [:],
+                usefulnessGracePeriod: .hours(1)
+            )
+            routingTable.logLevel = .warning
+
+            let peerCount = 50
+            let peers = (0..<peerCount).map { _ in
+                RandomDHTPeer(withCPL: Int.random(in: 0...8), wrt: local.dhtID, isReplaceable: true)
+            }
+
+            for peer in peers {
+                #expect(throws: Never.self) { try routingTable.addPeer(peer, isQueryPeer: true).wait() }
+            }
+
+            print(routingTable)
+
+            /// Get a list of all the peers that made it into our table
+            let peerInfos = try routingTable.getPeerInfos().wait()
+            #expect(peerInfos.count >= min(bucketSize, peerCount))
+            #expect(peerInfos.count >= 1)
+
+            /// Ensure all the peers in the table are still marked as replaceable
+            for pi in peerInfos {
+                #expect(try routingTable.find(id: pi).wait()?.replaceable == true)
+            }
+
+            /// Mark all peers irreplaceable
+            try routingTable.markAllPeersIrreplaceable().wait()
+
+            /// Ensure all the peers in our table are now marked as irreplaceable
+            for pi in peerInfos {
+                #expect(try routingTable.find(id: pi).wait()?.replaceable == false)
+            }
+
+            /// Mark all peers replaceable
+            try routingTable.markAllPeersReplaceable().wait()
+
+            /// Ensure all the peers in our table are now marked as replaceable
+            for pi in peerInfos {
+                #expect(try routingTable.find(id: pi).wait()?.replaceable == true)
+            }
         }
 
-        /// Mark all peers irreplaceable
-        try routingTable.markAllPeersIrreplaceable().wait()
+        @Test func testFindMultiplePeers() throws {
+            let local = RandomDHTPeer()
 
-        /// Ensure all the peers in our table are now marked as irreplaceable
-        for pi in peerInfos {
-            #expect(try routingTable.find(id: pi).wait()?.replaceable == false)
+            print(local.id)
+            print(local.dhtID.bytes)
+
+            let elg = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+            defer {
+                print("Shutting Down EventLoopGroup")
+                try! elg.syncShutdownGracefully()
+            }
+
+            let bucketSize: Int = 20
+            let routingTable = RoutingTable(
+                eventloop: elg.next(),
+                bucketSize: bucketSize,
+                localPeerID: local.id,
+                latency: .hours(1),
+                peerstoreMetrics: [:],
+                usefulnessGracePeriod: .hours(1)
+            )
+            routingTable.logLevel = .warning
+
+            let peerCount = 50
+            let peers = (0..<peerCount).map { _ in
+                RandomDHTPeer(withCPL: Int.random(in: 0...4), wrt: local.dhtID, isReplaceable: true)
+            }
+
+            for peer in peers {
+                #expect(throws: Never.self) { try routingTable.addPeer(peer, isQueryPeer: true).wait() }
+            }
+
+            print(routingTable)
+
+            /// The number of closest peers we're going to request
+            let expectedNearbyPeers: Int = 25
+
+            #expect(try routingTable.getPeerInfos().wait().count >= expectedNearbyPeers)
+
+            print("Searching for the \(expectedNearbyPeers) closest peers to \(peers.first!.id)")
+            routingTable.logLevel = .debug
+            let nearbyPeers = try routingTable.nearest(expectedNearbyPeers, peersTo: peers.first!).wait()
+            #expect(nearbyPeers.count == expectedNearbyPeers)
         }
 
-        /// Mark all peers replaceable
-        try routingTable.markAllPeersReplaceable().wait()
+        @Test func testPeerRemovedNotificationOnEviction() throws {
+            let local = RandomDHTPeer()
 
-        /// Ensure all the peers in our table are now marked as replaceable
-        for pi in peerInfos {
-            #expect(try routingTable.find(id: pi).wait()?.replaceable == true)
-        }
-    }
+            print(local.id)
+            print(local.dhtID.bytes)
 
-    @Test func testFindMultiplePeers() throws {
-        let local = RandomDHTPeer()
+            let elg = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+            defer {
+                print("Shutting Down EventLoopGroup")
+                try! elg.syncShutdownGracefully()
+            }
 
-        print(local.id)
-        print(local.dhtID.bytes)
+            let routingTable = RoutingTable(
+                eventloop: elg.next(),
+                bucketSize: 1,
+                localPeerID: local.id,
+                latency: .hours(1),
+                peerstoreMetrics: [:],
+                usefulnessGracePeriod: .hours(1)
+            )
+            routingTable.logLevel = .info
 
-        let elg = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        defer {
-            print("Shutting Down EventLoopGroup")
-            try! elg.syncShutdownGracefully()
-        }
+            var peersSet: [PeerID] = []
+            /// install our callback handlers
+            routingTable.peerAddedHandler = { peer in
+                print("Peer Added: \(peer)")
+                peersSet.append(peer)
+            }
+            routingTable.peerRemovedHandler = { peer in
+                print("Peer Removed: \(peer)")
+                peersSet.removeAll(where: { $0.id == peer.id })
+            }
 
-        let bucketSize: Int = 20
-        let routingTable = RoutingTable(
-            eventloop: elg.next(),
-            bucketSize: bucketSize,
-            localPeerID: local.id,
-            latency: .hours(1),
-            peerstoreMetrics: [:],
-            usefulnessGracePeriod: .hours(1)
-        )
-        routingTable.logLevel = .warning
+            /// Generate two random peers
+            let peer1 = RandomDHTPeer(withCPL: 0, wrt: local.dhtID, isReplaceable: false)
+            let peer2 = RandomDHTPeer(withCPL: 0, wrt: local.dhtID, isReplaceable: false)
 
-        let peerCount = 50
-        let peers = (0..<peerCount).map { _ in
-            RandomDHTPeer(withCPL: Int.random(in: 0...4), wrt: local.dhtID, isReplaceable: true)
-        }
+            #expect(local.dhtID.commonPrefixLength(with: peer1.dhtID) == 0)
+            #expect(local.dhtID.commonPrefixLength(with: peer2.dhtID) == 0)
 
-        for peer in peers {
-            #expect(throws: Never.self) { try routingTable.addPeer(peer, isQueryPeer: true).wait() }
-        }
+            /// Add the first peer, should work fine due to excess capacity
+            #expect(try routingTable.addPeer(peer1, isQueryPeer: true).wait())
+            #expect(try routingTable.find(id: peer1).wait() != nil)
+            #expect(peersSet.contains(where: { $0.id == peer1.id }))
 
-        print(routingTable)
+            /// Try and add the second peer, this should fail due to max capacity
+            #expect(try routingTable.addPeer(peer2, isQueryPeer: true).wait() == false)
+            #expect(try routingTable.find(id: peer2).wait() == nil)
+            #expect(peersSet.contains(where: { $0.id == peer2.id }) == false)
 
-        /// The number of closest peers we're going to request
-        let expectedNearbyPeers: Int = 25
+            /// Mark all peers (peer1) as replaceable
+            try routingTable.markAllPeersReplaceable().wait()
 
-        #expect(try routingTable.getPeerInfos().wait().count >= expectedNearbyPeers)
+            /// Try and add the second peer again, this should now succeed due to peer1 being marked as replaceable
+            #expect(try routingTable.addPeer(peer2, isQueryPeer: true, replacementStrategy: .anyReplaceable).wait())
+            #expect(try routingTable.find(id: peer2).wait() != nil)
+            #expect(peersSet.contains(where: { $0.id == peer2.id }))
 
-        print("Searching for the \(expectedNearbyPeers) closest peers to \(peers.first!.id)")
-        routingTable.logLevel = .debug
-        let nearbyPeers = try routingTable.nearest(expectedNearbyPeers, peersTo: peers.first!).wait()
-        #expect(nearbyPeers.count == expectedNearbyPeers)
-    }
-
-    @Test func testPeerRemovedNotificationOnEviction() throws {
-        let local = RandomDHTPeer()
-
-        print(local.id)
-        print(local.dhtID.bytes)
-
-        let elg = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        defer {
-            print("Shutting Down EventLoopGroup")
-            try! elg.syncShutdownGracefully()
+            /// Make sure peer1 is no longer in the routing table and has also been removed from our peersSet array
+            #expect(try routingTable.find(id: peer1).wait() == nil)
+            #expect(peersSet.contains(where: { $0.id == peer1.id }) == false)
         }
 
-        let routingTable = RoutingTable(
-            eventloop: elg.next(),
-            bucketSize: 1,
-            localPeerID: local.id,
-            latency: .hours(1),
-            peerstoreMetrics: [:],
-            usefulnessGracePeriod: .hours(1)
-        )
-        routingTable.logLevel = .info
+        /// `Bucket.maxCommonPrefixLength` used to pass a `>` closure to `max(by:)`, which expects
+        /// `areInIncreasingOrder` — so it returned the *minimum* CPL. It also force-unwrapped, trapping on an
+        /// empty bucket.
+        @Test func testBucketMaxCommonPrefixLength() throws {
+            let local = RandomDHTKey()
 
-        var peersSet: [PeerID] = []
-        /// install our callback handlers
-        routingTable.peerAddedHandler = { peer in
-            print("Peer Added: \(peer)")
-            peersSet.append(peer)
+            /// An empty bucket must not trap
+            let empty: Bucket = []
+            #expect(empty.maxCommonPrefixLength(target: local.bytes) == 0)
+
+            /// Peers with a known spread of CPLs — the answer is the largest, not the smallest.
+            let cpls = [0, 1, 4, 9, 2]
+            let bucket: Bucket = cpls.map { RandomDHTPeer(withCPL: $0, wrt: local) }
+
+            #expect(bucket.maxCommonPrefixLength(target: local.bytes) == cpls.max()!)
+
+            /// A single-peer bucket reports that peer's CPL
+            let single: Bucket = [RandomDHTPeer(withCPL: 6, wrt: local)]
+            #expect(single.maxCommonPrefixLength(target: local.bytes) == 6)
         }
-        routingTable.peerRemovedHandler = { peer in
-            print("Peer Removed: \(peer)")
-            peersSet.removeAll(where: { $0.id == peer.id })
+
+        /// `_nearest` sorted with `.rawValue >= 0`, which returns `true` for equal elements and so isn't a
+        /// strict weak ordering. Verify we now get a correctly ordered k-set out of a table holding well over
+        /// `k` peers.
+        @Test func testNearestReturnsCorrectlyOrderedKSet() throws {
+            let local = RandomDHTPeer()
+            let bucketSize = 20
+
+            let elg = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+            defer { try! elg.syncShutdownGracefully() }
+
+            let routingTable = RoutingTable(
+                eventloop: elg.next(),
+                bucketSize: bucketSize,
+                localPeerID: local.id,
+                latency: .hours(1),
+                peerstoreMetrics: [:],
+                usefulnessGracePeriod: .hours(1)
+            )
+
+            /// Fill the table with more than 2k peers so the bucket scan has to reach across buckets
+            var added: [PeerID] = []
+            for _ in 0..<(bucketSize * 3) {
+                let peer = RandomPeerID()
+                if try routingTable.addPeer(peer, isQueryPeer: true, replacementStrategy: .anyReplaceable).wait() {
+                    added.append(peer)
+                }
+            }
+            #expect(added.count > bucketSize)
+
+            let target = RandomDHTKey()
+            let nearest = try routingTable.nearest(bucketSize, peersToKey: target).wait()
+
+            #expect(nearest.count == bucketSize)
+
+            /// No duplicates
+            #expect(Set(nearest.map { $0.id.b58String }).count == nearest.count)
+
+            /// Strictly increasing distance from the target
+            for (lhs, rhs) in zip(nearest, nearest.dropFirst()) {
+                #expect(target.compareDistancesFromSelf(to: lhs.dhtID, and: rhs.dhtID) == .firstKey)
+            }
         }
 
-        /// Generate two random peers
-        let peer1 = RandomDHTPeer(withCPL: 0, wrt: local.dhtID, isReplaceable: false)
-        let peer2 = RandomDHTPeer(withCPL: 0, wrt: local.dhtID, isReplaceable: false)
+        /// A peer that's already in the table gets its `lastUsefulAt` bumped on first query. This used to bind
+        /// `if var peer = bucket.getPeer(...)`, mutating a throw-away copy of the struct.
+        @Test func testAddPeerBumpsLastUsefulAtInPlace() throws {
+            let local = RandomDHTPeer()
 
-        #expect(local.dhtID.commonPrefixLength(with: peer1.dhtID) == 0)
-        #expect(local.dhtID.commonPrefixLength(with: peer2.dhtID) == 0)
+            let elg = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+            defer { try! elg.syncShutdownGracefully() }
 
-        /// Add the first peer, should work fine due to excess capacity
-        #expect(try routingTable.addPeer(peer1, isQueryPeer: true).wait())
-        #expect(try routingTable.find(id: peer1).wait() != nil)
-        #expect(peersSet.contains(where: { $0.id == peer1.id }))
+            let routingTable = RoutingTable(
+                eventloop: elg.next(),
+                bucketSize: 20,
+                localPeerID: local.id,
+                latency: .hours(1),
+                peerstoreMetrics: [:],
+                usefulnessGracePeriod: .hours(1)
+            )
 
-        /// Try and add the second peer, this should fail due to max capacity
-        #expect(try routingTable.addPeer(peer2, isQueryPeer: true).wait() == false)
-        #expect(try routingTable.find(id: peer2).wait() == nil)
-        #expect(peersSet.contains(where: { $0.id == peer2.id }) == false)
-
-        /// Mark all peers (peer1) as replaceable
-        try routingTable.markAllPeersReplaceable().wait()
-
-        /// Try and add the second peer again, this should now succeed due to peer1 being marked as replaceable
-        #expect(try routingTable.addPeer(peer2, isQueryPeer: true, replacementStrategy: .anyReplaceable).wait())
-        #expect(try routingTable.find(id: peer2).wait() != nil)
-        #expect(peersSet.contains(where: { $0.id == peer2.id }))
-
-        /// Make sure peer1 is no longer in the routing table and has also been removed from our peersSet array
-        #expect(try routingTable.find(id: peer1).wait() == nil)
-        #expect(peersSet.contains(where: { $0.id == peer1.id }) == false)
-    }
-
-    /// `Bucket.maxCommonPrefixLength` used to pass a `>` closure to `max(by:)`, which expects
-    /// `areInIncreasingOrder` — so it returned the *minimum* CPL. It also force-unwrapped, trapping on an
-    /// empty bucket.
-    @Test func testBucketMaxCommonPrefixLength() throws {
-        let local = RandomDHTKey()
-
-        /// An empty bucket must not trap
-        let empty: Bucket = []
-        #expect(empty.maxCommonPrefixLength(target: local.bytes) == 0)
-
-        /// Peers with a known spread of CPLs — the answer is the largest, not the smallest.
-        let cpls = [0, 1, 4, 9, 2]
-        let bucket: Bucket = cpls.map { RandomDHTPeer(withCPL: $0, wrt: local) }
-
-        #expect(bucket.maxCommonPrefixLength(target: local.bytes) == cpls.max()!)
-
-        /// A single-peer bucket reports that peer's CPL
-        let single: Bucket = [RandomDHTPeer(withCPL: 6, wrt: local)]
-        #expect(single.maxCommonPrefixLength(target: local.bytes) == 6)
-    }
-
-    /// `_nearest` sorted with `.rawValue >= 0`, which returns `true` for equal elements and so isn't a
-    /// strict weak ordering. Verify we now get a correctly ordered k-set out of a table holding well over
-    /// `k` peers.
-    @Test func testNearestReturnsCorrectlyOrderedKSet() throws {
-        let local = RandomDHTPeer()
-        let bucketSize = 20
-
-        let elg = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        defer { try! elg.syncShutdownGracefully() }
-
-        let routingTable = RoutingTable(
-            eventloop: elg.next(),
-            bucketSize: bucketSize,
-            localPeerID: local.id,
-            latency: .hours(1),
-            peerstoreMetrics: [:],
-            usefulnessGracePeriod: .hours(1)
-        )
-
-        /// Fill the table with more than 2k peers so the bucket scan has to reach across buckets
-        var added: [PeerID] = []
-        for _ in 0..<(bucketSize * 3) {
             let peer = RandomPeerID()
-            if try routingTable.addPeer(peer, isQueryPeer: true, replacementStrategy: .anyReplaceable).wait() {
-                added.append(peer)
-            }
+
+            /// Add it as a non-query peer, so `lastUsefulAt` starts out nil
+            #expect(try routingTable.addPeer(peer, isQueryPeer: false).wait())
+            #expect(try routingTable.find(id: peer).wait()?.lastUsefulAt == nil)
+
+            /// Re-adding as a query peer returns false (already present) but must persist the usefulness bump
+            #expect(try routingTable.addPeer(peer, isQueryPeer: true).wait() == false)
+            #expect(try routingTable.find(id: peer).wait()?.lastUsefulAt != nil)
         }
-        #expect(added.count > bucketSize)
 
-        let target = RandomDHTKey()
-        let nearest = try routingTable.nearest(bucketSize, peersToKey: target).wait()
+        /// `markPeerIrreplaceable` called `_markPeerReplaceable`, doing the opposite of what it says.
+        @Test func testMarkPeerIrreplaceable() throws {
+            let local = RandomDHTPeer()
 
-        #expect(nearest.count == bucketSize)
+            let elg = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+            defer { try! elg.syncShutdownGracefully() }
 
-        /// No duplicates
-        #expect(Set(nearest.map { $0.id.b58String }).count == nearest.count)
+            let routingTable = RoutingTable(
+                eventloop: elg.next(),
+                bucketSize: 20,
+                localPeerID: local.id,
+                latency: .hours(1),
+                peerstoreMetrics: [:],
+                usefulnessGracePeriod: .hours(1)
+            )
 
-        /// Strictly increasing distance from the target
-        for (lhs, rhs) in zip(nearest, nearest.dropFirst()) {
-            #expect(target.compareDistancesFromSelf(to: lhs.dhtID, and: rhs.dhtID) == .firstKey)
+            let peer = RandomPeerID()
+            #expect(try routingTable.addPeer(peer, isQueryPeer: true, isReplaceable: true).wait())
+            #expect(try routingTable.find(id: peer).wait()?.replaceable == true)
+
+            let dhtPeer = try routingTable.find(id: peer).wait()!
+            #expect(try routingTable.markPeerIrreplaceable(dhtPeer).wait())
+            #expect(try routingTable.find(id: peer).wait()?.replaceable == false)
+
+            /// And the inverse still works
+            #expect(try routingTable.markPeerReplaceable(dhtPeer).wait())
+            #expect(try routingTable.find(id: peer).wait()?.replaceable == true)
         }
-    }
 
-    /// A peer that's already in the table gets its `lastUsefulAt` bumped on first query. This used to bind
-    /// `if var peer = bucket.getPeer(...)`, mutating a throw-away copy of the struct.
-    @Test func testAddPeerBumpsLastUsefulAtInPlace() throws {
-        let local = RandomDHTPeer()
-
-        let elg = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        defer { try! elg.syncShutdownGracefully() }
-
-        let routingTable = RoutingTable(
-            eventloop: elg.next(),
-            bucketSize: 20,
-            localPeerID: local.id,
-            latency: .hours(1),
-            peerstoreMetrics: [:],
-            usefulnessGracePeriod: .hours(1)
-        )
-
-        let peer = RandomPeerID()
-
-        /// Add it as a non-query peer, so `lastUsefulAt` starts out nil
-        #expect(try routingTable.addPeer(peer, isQueryPeer: false).wait())
-        #expect(try routingTable.find(id: peer).wait()?.lastUsefulAt == nil)
-
-        /// Re-adding as a query peer returns false (already present) but must persist the usefulness bump
-        #expect(try routingTable.addPeer(peer, isQueryPeer: true).wait() == false)
-        #expect(try routingTable.find(id: peer).wait()?.lastUsefulAt != nil)
-    }
-
-    /// `markPeerIrreplaceable` called `_markPeerReplaceable`, doing the opposite of what it says.
-    @Test func testMarkPeerIrreplaceable() throws {
-        let local = RandomDHTPeer()
-
-        let elg = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        defer { try! elg.syncShutdownGracefully() }
-
-        let routingTable = RoutingTable(
-            eventloop: elg.next(),
-            bucketSize: 20,
-            localPeerID: local.id,
-            latency: .hours(1),
-            peerstoreMetrics: [:],
-            usefulnessGracePeriod: .hours(1)
-        )
-
-        let peer = RandomPeerID()
-        #expect(try routingTable.addPeer(peer, isQueryPeer: true, isReplaceable: true).wait())
-        #expect(try routingTable.find(id: peer).wait()?.replaceable == true)
-
-        let dhtPeer = try routingTable.find(id: peer).wait()!
-        #expect(try routingTable.markPeerIrreplaceable(dhtPeer).wait())
-        #expect(try routingTable.find(id: peer).wait()?.replaceable == false)
-
-        /// And the inverse still works
-        #expect(try routingTable.markPeerReplaceable(dhtPeer).wait())
-        #expect(try routingTable.find(id: peer).wait()?.replaceable == true)
     }
 
 }

--- a/Tests/LibP2PKadDHTTests/RoutingTableTests.swift
+++ b/Tests/LibP2PKadDHTTests/RoutingTableTests.swift
@@ -1023,4 +1023,125 @@ struct RoutingTableTests {
         #expect(peersSet.contains(where: { $0.id == peer1.id }) == false)
     }
 
+    /// `Bucket.maxCommonPrefixLength` used to pass a `>` closure to `max(by:)`, which expects
+    /// `areInIncreasingOrder` — so it returned the *minimum* CPL. It also force-unwrapped, trapping on an
+    /// empty bucket.
+    @Test func testBucketMaxCommonPrefixLength() throws {
+        let local = RandomDHTKey()
+
+        /// An empty bucket must not trap
+        let empty: Bucket = []
+        #expect(empty.maxCommonPrefixLength(target: local.bytes) == 0)
+
+        /// Peers with a known spread of CPLs — the answer is the largest, not the smallest.
+        let cpls = [0, 1, 4, 9, 2]
+        let bucket: Bucket = cpls.map { RandomDHTPeer(withCPL: $0, wrt: local) }
+
+        #expect(bucket.maxCommonPrefixLength(target: local.bytes) == cpls.max()!)
+
+        /// A single-peer bucket reports that peer's CPL
+        let single: Bucket = [RandomDHTPeer(withCPL: 6, wrt: local)]
+        #expect(single.maxCommonPrefixLength(target: local.bytes) == 6)
+    }
+
+    /// `_nearest` sorted with `.rawValue >= 0`, which returns `true` for equal elements and so isn't a
+    /// strict weak ordering. Verify we now get a correctly ordered k-set out of a table holding well over
+    /// `k` peers.
+    @Test func testNearestReturnsCorrectlyOrderedKSet() throws {
+        let local = RandomDHTPeer()
+        let bucketSize = 20
+
+        let elg = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { try! elg.syncShutdownGracefully() }
+
+        let routingTable = RoutingTable(
+            eventloop: elg.next(),
+            bucketSize: bucketSize,
+            localPeerID: local.id,
+            latency: .hours(1),
+            peerstoreMetrics: [:],
+            usefulnessGracePeriod: .hours(1)
+        )
+
+        /// Fill the table with more than 2k peers so the bucket scan has to reach across buckets
+        var added: [PeerID] = []
+        for _ in 0..<(bucketSize * 3) {
+            let peer = RandomPeerID()
+            if try routingTable.addPeer(peer, isQueryPeer: true, replacementStrategy: .anyReplaceable).wait() {
+                added.append(peer)
+            }
+        }
+        #expect(added.count > bucketSize)
+
+        let target = RandomDHTKey()
+        let nearest = try routingTable.nearest(bucketSize, peersToKey: target).wait()
+
+        #expect(nearest.count == bucketSize)
+
+        /// No duplicates
+        #expect(Set(nearest.map { $0.id.b58String }).count == nearest.count)
+
+        /// Strictly increasing distance from the target
+        for (lhs, rhs) in zip(nearest, nearest.dropFirst()) {
+            #expect(target.compareDistancesFromSelf(to: lhs.dhtID, and: rhs.dhtID) == .firstKey)
+        }
+    }
+
+    /// A peer that's already in the table gets its `lastUsefulAt` bumped on first query. This used to bind
+    /// `if var peer = bucket.getPeer(...)`, mutating a throw-away copy of the struct.
+    @Test func testAddPeerBumpsLastUsefulAtInPlace() throws {
+        let local = RandomDHTPeer()
+
+        let elg = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { try! elg.syncShutdownGracefully() }
+
+        let routingTable = RoutingTable(
+            eventloop: elg.next(),
+            bucketSize: 20,
+            localPeerID: local.id,
+            latency: .hours(1),
+            peerstoreMetrics: [:],
+            usefulnessGracePeriod: .hours(1)
+        )
+
+        let peer = RandomPeerID()
+
+        /// Add it as a non-query peer, so `lastUsefulAt` starts out nil
+        #expect(try routingTable.addPeer(peer, isQueryPeer: false).wait())
+        #expect(try routingTable.find(id: peer).wait()?.lastUsefulAt == nil)
+
+        /// Re-adding as a query peer returns false (already present) but must persist the usefulness bump
+        #expect(try routingTable.addPeer(peer, isQueryPeer: true).wait() == false)
+        #expect(try routingTable.find(id: peer).wait()?.lastUsefulAt != nil)
+    }
+
+    /// `markPeerIrreplaceable` called `_markPeerReplaceable`, doing the opposite of what it says.
+    @Test func testMarkPeerIrreplaceable() throws {
+        let local = RandomDHTPeer()
+
+        let elg = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { try! elg.syncShutdownGracefully() }
+
+        let routingTable = RoutingTable(
+            eventloop: elg.next(),
+            bucketSize: 20,
+            localPeerID: local.id,
+            latency: .hours(1),
+            peerstoreMetrics: [:],
+            usefulnessGracePeriod: .hours(1)
+        )
+
+        let peer = RandomPeerID()
+        #expect(try routingTable.addPeer(peer, isQueryPeer: true, isReplaceable: true).wait())
+        #expect(try routingTable.find(id: peer).wait()?.replaceable == true)
+
+        let dhtPeer = try routingTable.find(id: peer).wait()!
+        #expect(try routingTable.markPeerIrreplaceable(dhtPeer).wait())
+        #expect(try routingTable.find(id: peer).wait()?.replaceable == false)
+
+        /// And the inverse still works
+        #expect(try routingTable.markPeerReplaceable(dhtPeer).wait())
+        #expect(try routingTable.find(id: peer).wait()?.replaceable == true)
+    }
+
 }

--- a/Tests/LibP2PKadDHTTests/ValueStoreTests.swift
+++ b/Tests/LibP2PKadDHTTests/ValueStoreTests.swift
@@ -21,147 +21,150 @@ import Testing
 
 @testable import LibP2PKadDHT
 
-/// Regression coverage for the value-store path
-/// (`storeNew` + `getUsingLookupList`).
-///
-/// Before this fix, `storeNew` returned `false` whenever the
-/// publisher's routing table was empty at call time — for
-/// example, immediately after `Application.start()` while the
-/// asynchronous bootstrap-peer addition was still in flight on
-/// the event loop. This broke any caller that wanted to publish
-/// a value soon after node startup.
-///
-/// The fix shifts `storeNew` to local-first semantics — the
-/// value lands in the publisher's own kv store synchronously,
-/// remote acceptance is best-effort, and the return value
-/// reflects local success. Heartbeat's `_shareDHTKVs` continues
-/// pushing the value out on the standard cadence.
-@Suite("Value Store Tests", .serialized)
-final class ValueStoreTests {
+extension LibP2PKadDHTTests {
+    /// Regression coverage for the value-store path
+    /// (`storeNew` + `getUsingLookupList`).
+    ///
+    /// Before this fix, `storeNew` returned `false` whenever the
+    /// publisher's routing table was empty at call time — for
+    /// example, immediately after `Application.start()` while the
+    /// asynchronous bootstrap-peer addition was still in flight on
+    /// the event loop. This broke any caller that wanted to publish
+    /// a value soon after node startup.
+    ///
+    /// The fix shifts `storeNew` to local-first semantics — the
+    /// value lands in the publisher's own kv store synchronously,
+    /// remote acceptance is best-effort, and the return value
+    /// reflects local success. Heartbeat's `_shareDHTKVs` continues
+    /// pushing the value out on the standard cadence.
+    @Suite("Value Store Tests", .serialized)
+    final class ValueStoreTests {
 
-    @Test
-    func testStoreNewWithEmptyRoutingTableReturnsTrue() throws {
-        let group = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
-        defer { try! group.syncShutdownGracefully() }
+        @Test
+        func testStoreNewWithEmptyRoutingTableReturnsTrue() throws {
+            let group = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
+            defer { try! group.syncShutdownGracefully() }
 
-        let dhtParams = KadDHT.NodeOptions(
-            connectionTimeout: .milliseconds(150),
-            maxConcurrentConnections: 3,
-            bucketSize: 5,
-            maxPeers: 15,
-            maxKeyValueStoreEntries: 10,
-            supportLocalNetwork: true
-        )
+            let dhtParams = KadDHT.NodeOptions(
+                connectionTimeout: .milliseconds(150),
+                maxConcurrentConnections: 3,
+                bucketSize: 5,
+                maxPeers: 15,
+                maxKeyValueStoreEntries: 10,
+                supportLocalNetwork: true
+            )
 
-        let node = try makeHost(
-            mode: .server,
-            options: dhtParams,
-            bootstrapPeers: [],
-            usingGroup: .shared(group)
-        )
-        try node.start()
-        defer { node.shutdown() }
+            let node = try makeHost(
+                mode: .server,
+                options: dhtParams,
+                bootstrapPeers: [],
+                usingGroup: .shared(group)
+            )
+            try node.start()
+            defer { node.shutdown() }
 
-        let key = try syntheticCID("local-first-empty-rt")
-        let record = TestRecord(
-            key: Data(key),
-            value: Data("hello-local-first".utf8)
-        )
-        let accepted = try node.dht.kadDHT.storeNew(key, value: record).wait()
-        #expect(accepted, "storeNew should accept even with empty routing table")
+            let key = try syntheticCID("local-first-empty-rt")
+            let record = TestRecord(
+                key: Data(key),
+                value: Data("hello-local-first".utf8)
+            )
+            let accepted = try node.dht.kadDHT.storeNew(key, value: record).wait()
+            #expect(accepted, "storeNew should accept even with empty routing table")
 
-        // Publisher's own get must succeed without any remote
-        // hop — local-first means the value is sitting in our
-        // own kv store.
-        let fetched = try node.dht.kadDHT.getUsingLookupList(key).wait()
-        #expect(fetched != nil, "publisher's own getUsingLookupList should hit the local kv")
-        #expect(fetched?.value == Data("hello-local-first".utf8))
-    }
-
-    @Test(.internalIntegrationTestsEnabled)
-    func testStoreNewCrossNodeRoundTrip() throws {
-        let group = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
-        defer { try! group.syncShutdownGracefully() }
-
-        let dhtParams = KadDHT.NodeOptions(
-            connectionTimeout: .milliseconds(500),
-            maxConcurrentConnections: 3,
-            bucketSize: 5,
-            maxPeers: 15,
-            maxKeyValueStoreEntries: 10,
-            supportLocalNetwork: true
-        )
-
-        let publisher = try makeHost(
-            mode: .server,
-            options: dhtParams,
-            bootstrapPeers: [],
-            usingGroup: .shared(group)
-        )
-        try publisher.start()
-
-        let consumer = try makeHost(
-            mode: .server,
-            options: dhtParams,
-            bootstrapPeers: [publisher.peerInfo],
-            usingGroup: .shared(group)
-        )
-        try consumer.start()
-        defer {
-            publisher.shutdown()
-            consumer.shutdown()
+            // Publisher's own get must succeed without any remote
+            // hop — local-first means the value is sitting in our
+            // own kv store.
+            let fetched = try node.dht.kadDHT.getUsingLookupList(key).wait()
+            #expect(fetched != nil, "publisher's own getUsingLookupList should hit the local kv")
+            #expect(fetched?.value == Data("hello-local-first".utf8))
         }
 
-        let key = try syntheticCID("local-first-cross-node")
-        let record = TestRecord(
-            key: Data(key),
-            value: Data("hello-cross-node".utf8)
-        )
-        let stored = try publisher.dht.kadDHT.storeNew(key, value: record).wait()
-        #expect(stored, "storeNew should accept (local-first semantics)")
+        @Test(.internalIntegrationTestsEnabled)
+        func testStoreNewCrossNodeRoundTrip() throws {
+            let group = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
+            defer { try! group.syncShutdownGracefully() }
 
-        // Give a moment for the consumer's iterative lookup to
-        // discover the publisher.
-        Thread.sleep(forTimeInterval: 0.5)
+            let dhtParams = KadDHT.NodeOptions(
+                connectionTimeout: .milliseconds(500),
+                maxConcurrentConnections: 3,
+                bucketSize: 5,
+                maxPeers: 15,
+                maxKeyValueStoreEntries: 10,
+                supportLocalNetwork: true
+            )
 
-        let fetched = try consumer.dht.kadDHT.getUsingLookupList(key).wait()
-        #expect(fetched != nil, "consumer should fetch publisher's value via iterative lookup")
-        #expect(fetched?.value == Data("hello-cross-node".utf8))
+            let publisher = try makeHost(
+                mode: .server,
+                options: dhtParams,
+                bootstrapPeers: [],
+                usingGroup: .shared(group)
+            )
+            try publisher.start()
+
+            let consumer = try makeHost(
+                mode: .server,
+                options: dhtParams,
+                bootstrapPeers: [publisher.peerInfo],
+                usingGroup: .shared(group)
+            )
+            try consumer.start()
+            defer {
+                publisher.shutdown()
+                consumer.shutdown()
+            }
+
+            let key = try syntheticCID("local-first-cross-node")
+            let record = TestRecord(
+                key: Data(key),
+                value: Data("hello-cross-node".utf8)
+            )
+            let stored = try publisher.dht.kadDHT.storeNew(key, value: record).wait()
+            #expect(stored, "storeNew should accept (local-first semantics)")
+
+            // Give a moment for the consumer's iterative lookup to
+            // discover the publisher.
+            Thread.sleep(forTimeInterval: 0.5)
+
+            let fetched = try consumer.dht.kadDHT.getUsingLookupList(key).wait()
+            #expect(fetched != nil, "consumer should fetch publisher's value via iterative lookup")
+            #expect(fetched?.value == Data("hello-cross-node".utf8))
+        }
+
+        // MARK: - Helpers
+
+        private func syntheticCID(_ tag: String) throws -> [UInt8] {
+            try CID(
+                version: .v1,
+                codec: .raw,
+                multihash: try Multihash(raw: tag.bytes, hashedWith: .sha2_256)
+            ).rawBuffer
+        }
+
+        private var nextPort: Int = Int.random(in: 13000..<14000)
+
+        private func makeHost(
+            mode: KadDHT.Mode = .client,
+            options: KadDHT.NodeOptions = .default,
+            bootstrapPeers: [PeerInfo] = [],
+            usingGroup: Application.EventLoopGroupProvider = .singleton
+        ) throws -> Application {
+            let lib = try Application(.testing, peerID: PeerID(.Ed25519), eventLoopGroupProvider: usingGroup)
+            lib.logger.logLevel = .warning
+            lib.security.use(.noise)
+            lib.muxers.use(.yamux)
+            lib.dht.use(.kadDHT(mode: mode, options: options, bootstrapPeers: bootstrapPeers, autoUpdate: false))
+            lib.servers.use(.tcp(host: "127.0.0.1", port: self.nextPort))
+            self.nextPort += 1
+            return lib
+        }
     }
 
-    // MARK: - Helpers
-
-    private func syntheticCID(_ tag: String) throws -> [UInt8] {
-        try CID(
-            version: .v1,
-            codec: .raw,
-            multihash: try Multihash(raw: tag.bytes, hashedWith: .sha2_256)
-        ).rawBuffer
+    private struct TestRecord: DHTRecord {
+        let key: Data
+        let value: Data
+        let author: Data = Data()
+        let signature: Data = Data()
+        let timeReceived: String = ""
     }
 
-    private var nextPort: Int = Int.random(in: 13000..<14000)
-
-    private func makeHost(
-        mode: KadDHT.Mode = .client,
-        options: KadDHT.NodeOptions = .default,
-        bootstrapPeers: [PeerInfo] = [],
-        usingGroup: Application.EventLoopGroupProvider = .singleton
-    ) throws -> Application {
-        let lib = try Application(.testing, peerID: PeerID(.Ed25519), eventLoopGroupProvider: usingGroup)
-        lib.logger.logLevel = .warning
-        lib.security.use(.noise)
-        lib.muxers.use(.yamux)
-        lib.dht.use(.kadDHT(mode: mode, options: options, bootstrapPeers: bootstrapPeers, autoUpdate: false))
-        lib.servers.use(.tcp(host: "127.0.0.1", port: self.nextPort))
-        self.nextPort += 1
-        return lib
-    }
-}
-
-private struct TestRecord: DHTRecord {
-    let key: Data
-    let value: Data
-    let author: Data = Data()
-    let signature: Data = Data()
-    let timeReceived: String = ""
 }


### PR DESCRIPTION
### What?
- We now use `Multihash`es for keys throughout kad-dht. 
- Go figured this out a long time ago https://github.com/libp2p/go-libp2p-kad-dht/pull/422
- This is extra confusing because v0 `CID`s are just `Multihash`es and the spec mentions `CID`s, but its probably from a time before v1 `CID`s came to be. I'm pretty sure we're just ment to use `Mulithash`es for everything.

### Changes:
- Updated our Query cases to accept `Multihash` `keys:[UInt8]` instead of `CID`s and `PeerID`s 
- fixed our maxCommonPrefixLength function and removed an unnecessary force unwrap
- Search for `Multihash`es, not `CID`s and not `PeerID`s

> [!NOTE]
> I guess rust-libp2p doesn't enforce the key being a `Multihash` (aka they support v1 `CID`s?) I haven't done any swift<->rust interop testing so I can't confirm this but their code suggests they just store / replay raw bytes?