### PR TITLE
Bucket Fixes

### DIFF
--- a/Sources/LibP2PKadDHT/RoutingTable/RoutingTable.swift
+++ b/Sources/LibP2PKadDHT/RoutingTable/RoutingTable.swift
@@ -758,14 +758,25 @@ class RoutingTable: EventLoopService, @unchecked Sendable {
             self.buckets.append(Bucket())
             return
         }
-        let newBucket = self.buckets[self.buckets.count - 1].split(
-            commonPrefixLength: self.buckets.count - 1,
-            targetID: self.localDHTID.bytes
-        )
-        self.buckets.append(newBucket)
 
-        if newBucket.count > self.bucketSize {
-            self._nextBucket()
+        /// Keep unfolding until the tail bucket actually has room for a new peer.
+        ///
+        /// A bucket never holds more than `bucketSize` peers, so `newBucket.count >= self.bucketSize`
+        /// means the split moved every peer out of the old tail, leaving the new tail just as full as
+        /// the bucket we started with. Stopping there would send `_addPeer` down the eviction path even
+        /// though another unfold would have made room for free.
+        /// - Note: see `testUnfoldsUntilTailBucketHasRoom` for more info
+        /// - Note: Each pass splits at a common prefix length one greater than the last, so this
+        ///   terminates once the split CPL exceeds the highest CPL in the bucket, at which point the
+        ///   new bucket comes back empty.
+        while true {
+            let newBucket = self.buckets[self.buckets.count - 1].split(
+                commonPrefixLength: self.buckets.count - 1,
+                targetID: self.localDHTID.bytes
+            )
+            self.buckets.append(newBucket)
+
+            if newBucket.count < self.bucketSize { return }
         }
     }
 

--- a/Sources/LibP2PKadDHT/RoutingTable/RoutingTable.swift
+++ b/Sources/LibP2PKadDHT/RoutingTable/RoutingTable.swift
@@ -606,20 +606,14 @@ class RoutingTable: EventLoopService, @unchecked Sendable {
             //    df.remove(peer)
             //}
 
-            /// Compact the buckets array, making sure we don't have empty buckets laying around...
-            while !self.buckets.isEmpty {
-                let lastBucketIndex = self.buckets.count - 1
-                if self.buckets.count > 1, self.buckets[lastBucketIndex].isEmpty {
-                    // If the last bucket is empty remove it...
-                    self.buckets.remove(at: lastBucketIndex)
-                } else if self.buckets.count >= 2 && self.buckets[lastBucketIndex - 1].isEmpty {
-                    // If the second to last bucket became empty, remove it...
-                    self.buckets.remove(at: lastBucketIndex - 1)
-                } else {
-                    break
-                }
+            /// Compact the buckets array by trimming any empty buckets off of the tail...
+            /// - Note: We only trim the tail. A bucket's index is the common prefix length of the
+            ///   peers it holds, so removing an interior bucket would shift every higher bucket down and
+            ///   permanently break the CPL
+            /// - Note: We always keep at least one bucket around.
+            while self.buckets.count > 1, self.buckets[self.buckets.count - 1].isEmpty {
+                self.buckets.removeLast()
             }
-            if self.buckets.isEmpty { self.buckets.append(Bucket()) }
 
             /// Invoke the peerRemovedHandler if one is set...
             self.peerRemovedHandler?(peer)
@@ -647,20 +641,14 @@ class RoutingTable: EventLoopService, @unchecked Sendable {
             //    df.remove(peer)
             //}
 
-            /// Compact the buckets array, making sure we don't have empty buckets laying around...
-            while !self.buckets.isEmpty {
-                let lastBucketIndex = self.buckets.count - 1
-                if self.buckets.count > 1, self.buckets[lastBucketIndex].isEmpty {
-                    // If the last bucket is empty remove it...
-                    self.buckets.remove(at: lastBucketIndex)
-                } else if self.buckets.count >= 2 && self.buckets[lastBucketIndex - 1].isEmpty {
-                    // If the second to last bucket became empty, remove it...
-                    self.buckets.remove(at: lastBucketIndex - 1)
-                } else {
-                    break
-                }
+            /// Compact the buckets array by trimming any empty buckets off of the tail...
+            /// - Note: We only trim the tail. A bucket's index is the common prefix length of the
+            ///   peers it holds, so removing an interior bucket would shift every higher bucket down and
+            ///   permanently break the CPL
+            /// - Note: We always keep at least one bucket around.
+            while self.buckets.count > 1, self.buckets[self.buckets.count - 1].isEmpty {
+                self.buckets.removeLast()
             }
-            if self.buckets.isEmpty { self.buckets.append(Bucket()) }
 
             /// Invoke the peerRemovedHandler if one is set...
             self.peerRemovedHandler?(peer.id)

--- a/Sources/LibP2PKadDHT/RoutingTable/RoutingTable.swift
+++ b/Sources/LibP2PKadDHT/RoutingTable/RoutingTable.swift
@@ -163,7 +163,7 @@ class RoutingTable: EventLoopService, @unchecked Sendable {
         replacementStrategy: ReplacementStrategy? = nil
     ) throws -> Bool {
 
-        let bucketID = self._bucketIDFor(peer: peer)
+        var bucketID = self._bucketIDFor(peer: peer)
 
         let now = Date().timeIntervalSince1970
         var lastUsefulAt: TimeInterval?
@@ -218,7 +218,8 @@ class RoutingTable: EventLoopService, @unchecked Sendable {
         if bucketID == self.buckets.count - 1 {
             self._nextBucket()
 
-            let bucketID = self._bucketIDFor(peer: peer)
+            /// The split may have moved this peer into a different bucket
+            bucketID = self._bucketIDFor(peer: peer)
 
             /// If there's room for the peer after splitting, add the peer to the bucket...
             if self.buckets[bucketID].count < self.bucketSize {
@@ -244,6 +245,8 @@ class RoutingTable: EventLoopService, @unchecked Sendable {
             /// We don't really need a stable sort here as it doesn't matter which peer we evict as long as it's a replaceable peer
             if let replaceablePeer = self.buckets[bucketID].shuffled().last(where: { $0.replaceable }) {
                 if self._removePeer(replaceablePeer) {
+                    /// `_removePeer` may have trimmed empty buckets, so update `bucketID` before using it
+                    bucketID = self._bucketIDFor(peer: peer)
                     self.buckets[bucketID].pushFront(
                         DHTPeerInfo(
                             id: peer,
@@ -272,6 +275,8 @@ class RoutingTable: EventLoopService, @unchecked Sendable {
                     "Found the furthest replaceable peer in bucket[\(bucketID)], attempting to replace it with this peer"
                 )
                 if self._removePeer(replaceablePeer) {
+                    /// `_removePeer` may have trimmed empty buckets, so update `bucketID` before using it
+                    bucketID = self._bucketIDFor(peer: peer)
                     self.buckets[bucketID].pushFront(
                         DHTPeerInfo(
                             id: peer,
@@ -295,6 +300,8 @@ class RoutingTable: EventLoopService, @unchecked Sendable {
             /// We don't really need a stable sort here as it doesn't matter which peer we evict as long as it's a replaceable peer
             if let replaceablePeer = self.buckets[bucketID].last(where: { $0.replaceable }) {
                 if self._removePeer(replaceablePeer) {
+                    /// `_removePeer` may have trimmed empty buckets, so update `bucketID` before using it
+                    bucketID = self._bucketIDFor(peer: peer)
                     self.buckets[bucketID].pushFront(
                         DHTPeerInfo(
                             id: peer,
@@ -323,6 +330,8 @@ class RoutingTable: EventLoopService, @unchecked Sendable {
                     "Found a peer in bucket[\(bucketID)] that's replaceable and further away from us than the new peer, attempting to replace it with this peer"
                 )
                 if self._removePeer(replaceablePeer) {
+                    /// `_removePeer` may have trimmed empty buckets, so update `bucketID` before using it
+                    bucketID = self._bucketIDFor(peer: peer)
                     self.buckets[bucketID].pushFront(
                         DHTPeerInfo(
                             id: peer,
@@ -367,7 +376,7 @@ class RoutingTable: EventLoopService, @unchecked Sendable {
         replacementStrategy: ReplacementStrategy? = nil
     ) throws -> EventLoopFuture<Bool> {
         self.eventLoop.submit {
-            let bucketID = self._bucketIDFor(peer: peer)
+            var bucketID = self._bucketIDFor(peer: peer)
             self.logger.debug("Attempting to add peer to bucket[\(bucketID)]")
 
             let now = Date().timeIntervalSince1970
@@ -426,7 +435,8 @@ class RoutingTable: EventLoopService, @unchecked Sendable {
                 self.logger.debug("Attempting to unfold the last wildcard bucket")
                 self._nextBucket()
 
-                let bucketID = self._bucketIDFor(peer: peer)
+                /// The split may have moved this peer into a different bucket
+                bucketID = self._bucketIDFor(peer: peer)
                 self.logger.debug("Now attempting to add peer to bucket[\(bucketID)] after split")
 
                 /// If there's room for the peer after splitting, add the peer to the bucket...
@@ -458,6 +468,8 @@ class RoutingTable: EventLoopService, @unchecked Sendable {
                         "Found a peer in bucket[\(bucketID)] that's replaceable, attempting to replace it with this peer"
                     )
                     if self._removePeer(replaceablePeer) {
+                        /// `_removePeer` may have trimmed empty buckets, so update `bucketID` before using it
+                        bucketID = self._bucketIDFor(peer: peer)
                         self.buckets[bucketID].pushFront(
                             DHTPeerInfo(
                                 id: peer.id,
@@ -486,6 +498,8 @@ class RoutingTable: EventLoopService, @unchecked Sendable {
                         "Found the furthest reaplaceable peer in bucket[\(bucketID)], attempting to replace it with this peer"
                     )
                     if self._removePeer(replaceablePeer) {
+                        /// `_removePeer` may have trimmed empty buckets, so update `bucketID` before using it
+                        bucketID = self._bucketIDFor(peer: peer)
                         self.buckets[bucketID].pushFront(
                             DHTPeerInfo(
                                 id: peer.id,
@@ -512,6 +526,8 @@ class RoutingTable: EventLoopService, @unchecked Sendable {
                         "Found a peer in bucket[\(bucketID)] that's replaceable, attempting to replace it with this peer"
                     )
                     if self._removePeer(replaceablePeer) {
+                        /// `_removePeer` may have trimmed empty buckets, so update `bucketID` before using it
+                        bucketID = self._bucketIDFor(peer: peer)
                         self.buckets[bucketID].pushFront(
                             DHTPeerInfo(
                                 id: peer.id,
@@ -542,6 +558,8 @@ class RoutingTable: EventLoopService, @unchecked Sendable {
                         "Found a peer in bucket[\(bucketID)] that's replaceable and further away from us than the new peer, attempting to replace it with this peer"
                     )
                     if self._removePeer(replaceablePeer) {
+                        /// `_removePeer` may have trimmed empty buckets, so update `bucketID` before using it
+                        bucketID = self._bucketIDFor(peer: peer)
                         self.buckets[bucketID].pushFront(
                             DHTPeerInfo(
                                 id: peer.id,

--- a/Tests/LibP2PKadDHTTests/RoutingTableTests.swift
+++ b/Tests/LibP2PKadDHTTests/RoutingTableTests.swift
@@ -397,9 +397,12 @@ extension LibP2PKadDHTTests {
             #expect(try routingTable.getPeerInfos().wait().count == 2)
             print(routingTable)
 
-            /// Remove a peer from the second to last bucket (the first bucket in this case) and ensure it collapses as expected
+            /// Remove a peer from the second to last bucket (the first bucket in this case) and ensure it
+            /// does *not* collapse. A bucket's index is the common prefix length of the peers it holds,
+            /// so dropping bucket[0] here would shift bucket[1] down to index 0 and strand peer1 in a
+            /// bucket that `_bucketIDFor` would never look in. Only trailing empty buckets get trimmed.
             #expect(try routingTable.removePeer(peer0).wait())
-            #expect(try routingTable.bucketCount.wait() == 1)
+            #expect(try routingTable.bucketCount.wait() == 2)
             #expect(try routingTable.getPeerInfos().wait().count == 1)
             #expect(try routingTable.getPeerInfos().wait().contains(where: { $0.id == peer1.id }))
             print(routingTable)
@@ -445,16 +448,19 @@ extension LibP2PKadDHTTests {
             /// b[2] = [2]
             /// b[3] = [3]
             /// ---------------------------------------
-            /// removing peer2 next causes a cascading collapse that ends up 'removing' bucket 1 and 2
+            /// removing peer2 leaves a second empty interior bucket, still without triggering a collapse
             #expect(try routingTable.removePeer(peer2).wait())
             /// 📒 --------------------------------- 📒
             /// Routing Table [<peer.ID dJwpME>]
-            /// Bucket Count: 2 buckets of size: 1
+            /// Bucket Count: 4 buckets of size: 1
             /// Total Peers: 2
             /// b[0] = [0]
-            /// b[1] = [3]
+            /// b[1] = []
+            /// b[2] = []
+            /// b[3] = [3]
             /// ---------------------------------------
-            /// removing peer3 from the last bucket also deletes it resulting in a single peer0 in bucket[0]
+            /// removing peer3 empties the last bucket, so the whole empty tail (b[3], b[2], b[1]) is
+            /// trimmed in one pass, leaving a single peer0 in bucket[0]
             #expect(try routingTable.removePeer(peer3).wait())
             /// 📒 --------------------------------- 📒
             /// Routing Table [<peer.ID dJwpME>]

--- a/Tests/LibP2PKadDHTTests/RoutingTableTests.swift
+++ b/Tests/LibP2PKadDHTTests/RoutingTableTests.swift
@@ -398,7 +398,7 @@ extension LibP2PKadDHTTests {
             print(routingTable)
 
             /// Remove a peer from the second to last bucket (the first bucket in this case) and ensure it
-            /// does *not* collapse. A bucket's index is the common prefix length of the peers it holds,
+            /// does not collapse. A bucket's index is the common prefix length of the peers it holds,
             /// so dropping bucket[0] here would shift bucket[1] down to index 0 and strand peer1 in a
             /// bucket that `_bucketIDFor` would never look in. Only trailing empty buckets get trimmed.
             #expect(try routingTable.removePeer(peer0).wait())
@@ -1150,6 +1150,64 @@ extension LibP2PKadDHTTests {
             /// And the inverse still works
             #expect(try routingTable.markPeerReplaceable(dhtPeer).wait())
             #expect(try routingTable.find(id: peer).wait()?.replaceable == true)
+        }
+
+        /// `_nextBucket` stopped unfolding on `newBucket.count > bucketSize`, which can never be true
+        /// (a bucket never exceeds `bucketSize` and a split returns a subset of what it split). So when a
+        /// split moved *every* peer into the new tail bucket, we'd stop with the tail still full and fall
+        /// through to eviction instead of unfolding again. Verify we now keep unfolding until there's room.
+        @Test func testUnfoldsUntilTailBucketHasRoom() throws {
+            let local = RandomDHTPeer()
+
+            let elg = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+            defer { try! elg.syncShutdownGracefully() }
+
+            let routingTable = RoutingTable(
+                eventloop: elg.next(),
+                bucketSize: 2,
+                localPeerID: local.id,
+                latency: .hours(1),
+                peerstoreMetrics: [:],
+                usefulnessGracePeriod: .hours(1)
+            )
+
+            /// Two peers that are close to us, but not to each other, fill the lone wildcard bucket.
+            /// Both have a CPL > 0, so splitting bucket[0] moves *both* of them into the new bucket.
+            let peerCPL5 = RandomDHTPeer(withCPL: 5, wrt: local.dhtID, isReplaceable: false)
+            let peerCPL6 = RandomDHTPeer(withCPL: 6, wrt: local.dhtID, isReplaceable: false)
+            #expect(try routingTable.addPeer(peerCPL5, isQueryPeer: true).wait())
+            #expect(try routingTable.addPeer(peerCPL6, isQueryPeer: true).wait())
+            #expect(try routingTable.bucketCount.wait() == 1)
+            print(routingTable)
+
+            /// bucket[0] is now full. Every peer in it is irreplaceable, so if we stop unfolding early
+            /// the eviction path has nothing to evict and this add fails.
+            let peerCPL7 = RandomDHTPeer(withCPL: 7, wrt: local.dhtID, isReplaceable: false)
+            #expect(try routingTable.addPeer(peerCPL7, isQueryPeer: true).wait())
+            print(routingTable)
+
+            /// Nobody got evicted along the way
+            #expect(try routingTable.totalPeers().wait() == 3)
+            #expect(try routingTable.find(id: peerCPL5).wait()?.id == peerCPL5.id)
+            #expect(try routingTable.find(id: peerCPL6).wait()?.id == peerCPL6.id)
+            #expect(try routingTable.find(id: peerCPL7).wait()?.id == peerCPL7.id)
+
+            /// We unfolded far enough to separate the CPL 5 peer from the CPL 6/7 peers, which needs
+            /// buckets all the way out to index 6. Each peer now sits in the bucket matching its CPL.
+            #expect(try routingTable.bucketCount.wait() == 7)
+            #expect(try routingTable.numberOfPeers(withCommonPrefixLength: 5).wait() == 1)
+            #expect(try routingTable.numberOfPeers(withCommonPrefixLength: 6).wait() == 1)
+            #expect(try routingTable.numberOfPeers(withCommonPrefixLength: 7).wait() == 1)
+
+            /// The unfold left empty interior buckets behind. That's expected - a bucket's index is the
+            /// CPL of the peers it holds, so those slots have to stay to keep the higher buckets addressable.
+            for cpl in 0..<5 {
+                #expect(try routingTable.numberOfPeers(withCommonPrefixLength: cpl).wait() == 0)
+            }
+
+            /// And the table still answers lookups correctly across those gaps
+            #expect(try routingTable.nearest(3, peersTo: peerCPL7).wait().count == 3)
+            #expect(try routingTable.nearestPeer(to: peerCPL5).wait()?.id == peerCPL5.id)
         }
 
     }


### PR DESCRIPTION
### What?
This PR makes a few changes to how our `RoutingTable` manages its `Bucket`s (unfolding and safer indexing)

### Changes:
- We recompute `bucketID` after calling muting methods (this prevent index out of bounds errors)
- We don't collapse interior empty `Bucket`s (this maintains the CPL structure)
- We collapse empty tail `Bucket`s correctly
- in `addPeer` we unfold `Bucket`s until there's space for the peer (previously we would reject the peer if there wasn't space after a single unfold)