### PR TITLE
Misc Fixes

### DIFF
--- a/Sources/LibP2PKadDHT/Lookup/Lookup.swift
+++ b/Sources/LibP2PKadDHT/Lookup/Lookup.swift
@@ -61,10 +61,10 @@ final class Lookup: @unchecked Sendable {
         self.completionPromise = self.eventLoop.makePromise(of: Void.self)
     }
 
-    deinit { print("Lookup::deinit") }
+    deinit { self.logger.debug("Lookup::deinit") }
 
     private func tearDownSelf() {
-        print("Lookup::tearDownSelf")
+        self.logger.debug("Lookup::tearDownSelf")
         if !self.sharedELG {
             try? self.eventLoop.close()
             self.group.shutdownGracefully(queue: .global()) { _ in print("Lookup::ELG shutdown") }
@@ -129,7 +129,7 @@ final class Lookup: @unchecked Sendable {
         self.eventLoop.flatSubmit {
             if decrementingRequests { self.requestsInProgress -= 1 }
             guard !self.canceled else {
-                self.logger.warning("Lookup Cancelled, Worker Terminating")
+                self.logger.debug("Lookup Cancelled, Worker Terminating")
                 return self.eventLoop.makeSucceededVoidFuture()
             }
             guard let next = self.list.next() else {
@@ -139,10 +139,10 @@ final class Lookup: @unchecked Sendable {
                         self._recursivelyQueryForTarget(on: on)
                     }.futureResult
                 }
-                self.logger.warning("Worker Terminating - No More Work")
+                self.logger.debug("Worker Terminating - No More Work")
                 return self.eventLoop.makeSucceededVoidFuture()
             }
-            self.logger.info("Querying \(next.peer.b58String) for id: \(self.target.b58String)")
+            self.logger.debug("Querying \(next.peer.b58String) for id: \(self.target.b58String)")
             self.requestsInProgress += 1
             return on.flatSubmit {
                 self.host._sendQuery(.findNode(key: self.target.id), to: next, on: on).flatMapAlways { result in
@@ -228,10 +228,10 @@ final class KeyLookup: @unchecked Sendable {
         )
     }
 
-    deinit { print("KeyLookup::deinit") }
+    deinit { self.logger.debug("KeyLookup::deinit") }
 
     func tearDownSelf() {
-        print("KeyLookup::tearDownSelf")
+        self.logger.debug("KeyLookup::tearDownSelf")
         if !self.sharedELG {
             try? self.eventLoop.close()
             self.group.shutdownGracefully(queue: .global()) { _ in print("KeyLookup::ELG shutdown") }

--- a/Tests/LibP2PKadDHTTests/InternalNetworkTests.swift
+++ b/Tests/LibP2PKadDHTTests/InternalNetworkTests.swift
@@ -244,6 +244,7 @@ extension LibP2PKadDHTTests {
                     options: dhtParams,
                     bootstrapPeers: [],
                     autoHeartbeat: false,
+                    logLevel: .critical,
                     usingGroup: .shared(group)
                 )
             ]
@@ -254,6 +255,7 @@ extension LibP2PKadDHTTests {
                         options: dhtParams,
                         bootstrapPeers: [nodes[i - 1].peerInfo],
                         autoHeartbeat: false,
+                        logLevel: .critical,
                         usingGroup: .shared(group)
                     )
                 )
@@ -401,10 +403,11 @@ extension LibP2PKadDHTTests {
             options: KadDHT.NodeOptions = .default,
             bootstrapPeers: [PeerInfo] = BootstrapPeerDiscovery.IPFSBootNodes,
             autoHeartbeat: Bool = false,
+            logLevel: Logger.Level = .notice,
             usingGroup: Application.EventLoopGroupProvider = .singleton
         ) throws -> Application {
             let lib = try Application(.testing, peerID: PeerID(.Ed25519), eventLoopGroupProvider: usingGroup)
-            lib.logger.logLevel = .notice
+            lib.logger.logLevel = logLevel
             lib.security.use(.noise)
             lib.muxers.use(.yamux)
             lib.dht.use(

--- a/Tests/LibP2PKadDHTTests/InternalNetworkTests.swift
+++ b/Tests/LibP2PKadDHTTests/InternalNetworkTests.swift
@@ -265,12 +265,16 @@ extension LibP2PKadDHTTests {
             // Add the last nodes info to the first node
             try nodes[0].peers.add(peerInfo: nodes.last!.peerInfo).wait()
 
-            for _ in 0..<5 {
+            for round in 0..<5 {
                 for node in nodes {
                     try node.dht.kadDHT.heartbeat().wait()
                 }
 
-                printNetwork(nodes.map { $0.dht.kadDHT })
+                /// Kademlia guarantees a local invariant, not a global ordering: each node should
+                /// know the k peers nearest itself. Grade that directly — it converges toward 100%
+                /// as the heartbeats progress.
+                print("--- after heartbeat \(round + 1) ---")
+                printKClosestCompleteness(nodes.map { $0.dht.kadDHT })
             }
 
             for i in 0..<numberOfNodes {

--- a/Tests/LibP2PKadDHTTests/MiscFunctions.swift
+++ b/Tests/LibP2PKadDHTTests/MiscFunctions.swift
@@ -191,3 +191,134 @@ func sumByteArrays(_ bytes1: [UInt8], bytes2: [UInt8]) -> [UInt8] {
     if carry { summation.insert(1, at: 0) }
     return summation
 }
+
+// MARK: - k-closest completeness
+
+/// Grades a whole simulated network against the routing tables it *should* have converged on.
+///
+/// Kademlia doesn't impose a global ordering on nodes, so there's no meaningful "is the network
+/// sorted?" question to ask. The invariant it actually guarantees is local: every node should know
+/// the `k` peers nearest to itself in XOR keyspace. That's what this measures.
+///
+/// For each node we compute the theoretically optimal bucket — the `k` nearest of all the other
+/// nodes in the network, which we can determine exactly because the test owns every node — and
+/// check how many of them are actually in that node's routing table. Unlike a positional/ordering
+/// score, this is sign-stable, has a fixed 0–100% scale, and degrades meaningfully: a node missing
+/// 2 of its 8 nearest peers scores 75% whether the network has 20 nodes or 20,000.
+struct KClosestCompleteness {
+    /// One node's grade.
+    struct NodeGrade {
+        let peer: PeerID
+        /// The `k` nearest other nodes in the network — the bucket this node *should* hold.
+        let expected: [PeerID]
+        /// Of `expected`, the ones actually present in the node's routing table.
+        let found: [PeerID]
+        /// Of `expected`, the ones absent from the node's routing table.
+        let missing: [PeerID]
+        /// Total peers in the routing table, including ones outside the k-closest set.
+        let tableSize: Int
+
+        /// `1.0` when the node holds every one of its k nearest peers.
+        ///
+        /// A node in a network of one has nothing to know, which we treat as trivially complete
+        /// rather than as a divide-by-zero.
+        var score: Double {
+            guard !expected.isEmpty else { return 1.0 }
+            return Double(found.count) / Double(expected.count)
+        }
+    }
+
+    let k: Int
+    let grades: [NodeGrade]
+
+    /// Mean per-node completeness across the network, `0.0...1.0`.
+    var score: Double {
+        guard !grades.isEmpty else { return 1.0 }
+        return grades.reduce(0.0) { $0 + $1.score } / Double(grades.count)
+    }
+
+    /// Nodes holding all `k` of their nearest peers.
+    var perfectNodes: Int { grades.filter { $0.score >= 1.0 }.count }
+
+    /// The single least-converged node, useful for spotting one straggler dragging the mean down.
+    var worst: NodeGrade? { grades.min { $0.score < $1.score } }
+}
+
+/// Grades `nodes` on k-closest completeness.
+///
+/// - Parameters:
+///   - nodes: Every node in the simulated network. The grade is only meaningful if this is the
+///     *complete* set, since the optimal bucket is derived from it.
+///   - k: Bucket size to grade against. Defaults to each node's own `routingTable.bucketSize`,
+///     which is what that node is actually trying to fill. Capped at `nodes.count - 1` so a
+///     network smaller than `k + 1` can still reach 100%.
+/// - Note: Throws rather than force-unwrapping the routing-table futures so a transport hiccup
+///   surfaces as a test failure instead of a crash in the diagnostic.
+func kClosestCompleteness(_ nodes: [KadDHT.Node], k: Int? = nil) throws -> KClosestCompleteness {
+    /// Precompute each node's keyspace position once — `KadDHT.Key` re-hashes the PeerID on every
+    /// init, and the comparator below runs O(n log n) times per node.
+    let positions = nodes.map { (peer: $0.peerID, key: KadDHT.Key($0.peerID, keySpace: .xor)) }
+
+    var grades: [KClosestCompleteness.NodeGrade] = []
+    var effectiveK = 0
+
+    for (index, node) in nodes.enumerated() {
+        let selfKey = positions[index].key
+        let bucketSize = min(k ?? node.routingTable.bucketSize, max(nodes.count - 1, 0))
+        effectiveK = max(effectiveK, bucketSize)
+
+        /// The optimal bucket: every other node, sorted by XOR distance from this one, truncated
+        /// to `bucketSize`.
+        let expected = positions.enumerated()
+            .filter { $0.offset != index }
+            .map { $0.element }
+            .sorted { selfKey.compareDistancesFromSelf(to: $0.key, and: $1.key) == .firstKey }
+            .prefix(bucketSize)
+            .map { $0.peer }
+
+        let table = try node.routingTable.getPeerInfos().wait()
+        /// Match on `b58String` — `PeerID` equality is fine, but a string set keeps this O(n)
+        /// instead of O(n²) across the containment checks below.
+        let held = Set(table.map { $0.id.b58String })
+
+        grades.append(
+            KClosestCompleteness.NodeGrade(
+                peer: node.peerID,
+                expected: expected,
+                found: expected.filter { held.contains($0.b58String) },
+                missing: expected.filter { !held.contains($0.b58String) },
+                tableSize: table.count
+            )
+        )
+    }
+
+    return KClosestCompleteness(k: effectiveK, grades: grades)
+}
+
+/// Prints a k-closest completeness report for `nodes`.
+///
+/// ```
+/// k-closest completeness: 92.5% (k=8) — 15/20 nodes optimal
+///   <peer.ID RGAUcD>  6/8  (table: 14)  missing: <peer.ID DcbL2i>, <peer.ID MkPNVp>
+///   <peer.ID 9wCzih>  7/8  (table: 11)  missing: <peer.ID MGALkM>
+/// ```
+///
+/// Only imperfect nodes are listed, so a fully converged network prints a single summary line.
+internal func printKClosestCompleteness(_ nodes: [KadDHT.Node], k: Int? = nil) {
+    guard let report = try? kClosestCompleteness(nodes, k: k) else {
+        print("k-closest completeness: <unavailable — routing table read failed>")
+        return
+    }
+
+    let percent = String(format: "%.1f", report.score * 100)
+    print(
+        "k-closest completeness: \(percent)% (k=\(report.k)) — \(report.perfectNodes)/\(report.grades.count) nodes optimal"
+    )
+
+    for grade in report.grades.sorted(by: { $0.score < $1.score }) where grade.score < 1.0 {
+        let missing = grade.missing.map { $0.description }.joined(separator: ", ")
+        print(
+            "  \(grade.peer) \(grade.found.count)/\(grade.expected.count) (table: \(grade.tableSize)) missing: \(missing)"
+        )
+    }
+}

--- a/Tests/LibP2PKadDHTTests/ProvideTests.swift
+++ b/Tests/LibP2PKadDHTTests/ProvideTests.swift
@@ -38,8 +38,7 @@ extension LibP2PKadDHTTests {
     @Suite("Provide Tests", .serialized)
     final class ProvideTests {
 
-        @Test
-        func testProvideStoresLocallyWithoutAnnounce() throws {
+        @Test func testProvideStoresLocallyWithoutAnnounce() throws {
             let app = try makeApplication()
             defer { app.shutdown() }
             try app.start()
@@ -66,8 +65,7 @@ extension LibP2PKadDHTTests {
             #expect(node.providerRecordAddedAt[composite] != nil, "addedAt should be tracked")
         }
 
-        @Test
-        func testProvideExpiryPruning() throws {
+        @Test func testProvideExpiryPruning() throws {
             let app = try makeApplication()
             defer { app.shutdown() }
             try app.start()
@@ -96,8 +94,7 @@ extension LibP2PKadDHTTests {
             #expect(node.providerRecordAddedAt[composite] == nil, "stale timestamp entry should be removed")
         }
 
-        @Test
-        func testProvideRenewalEligibility() throws {
+        @Test func testProvideRenewalEligibility() throws {
             let app = try makeApplication()
             defer { app.shutdown() }
             try app.start()
@@ -125,8 +122,7 @@ extension LibP2PKadDHTTests {
             #expect(refreshed > staleTime, "renewal job should refresh addedAt past the stale time")
         }
 
-        @Test
-        func testProvideBeforeBootstrap() throws {
+        @Test func testProvideBeforeBootstrap() throws {
             let app = try makeApplication()
             defer { app.shutdown() }
             try app.start()
@@ -146,7 +142,7 @@ extension LibP2PKadDHTTests {
             #expect(stored.count == 1, "local provider entry should exist")
         }
 
-        func testProvideThenFindRoundTrip() throws {
+        @Test func testProvideThenFindRoundTrip() throws {
             let group = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
             defer { try! group.syncShutdownGracefully() }
             let dhtParams = KadDHT.NodeOptions(
@@ -186,7 +182,7 @@ extension LibP2PKadDHTTests {
             #expect(!providers.isEmpty, "node B should have found at least one provider for the CID")
         }
 
-        func testProvideMultipleKeys() throws {
+        @Test func testProvideMultipleKeys() throws {
             let group = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
             defer { try! group.syncShutdownGracefully() }
             let dhtParams = KadDHT.NodeOptions(


### PR DESCRIPTION
### What?
This PR contains misc fixes and a cool new kClosestCompleteness score

### Changes:
- Replaced some print statements with log
- Reduced some logs levels (they we're set high for debugging and never changed), this should result in a quieter console
- Re-enable two provider tests that were accidentally dropped
- Introduced a `KClosestCompleteness` check (Claude Opus) that lets us score the shape / ordering of our simulated network in the `testInternalNetwork_SortingTest()` test, you can watch the peers fill their k buckets up with their closest peers as they discover one another during each heartbeat.