### PR TITLE
RFC3339 and Record Timestamps

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -54,6 +54,7 @@ let package = Package(
             name: "LibP2PKadDHTTests",
             dependencies: [
                 "LibP2PKadDHT",
+                .product(name: "LibP2PTesting", package: "swift-libp2p"),
                 .product(name: "LibP2PNoise", package: "swift-libp2p-noise"),
                 .product(name: "LibP2PYAMUX", package: "swift-libp2p-yamux"),
                 .product(name: "LibP2PCrypto", package: "swift-libp2p-crypto"),

--- a/Sources/LibP2PKadDHT/Node.swift
+++ b/Sources/LibP2PKadDHT/Node.swift
@@ -92,16 +92,18 @@ public enum KadDHT {
         /// payload.
         var localProviderCIDs: [KadDHT.Key: [UInt8]] = [:]
 
-        /// Provider records older than this are pruned on heartbeat,
-        /// matching the libp2p Kad DHT spec default. Records we
-        /// published ourselves are re-issued at
-        /// ``providerRecordRepublishInterval`` to stay fresh.
-        let providerRecordTTL: TimeInterval = 24 * 60 * 60
+        /// Provider records older than this are pruned on heartbeat.
+        ///
+        /// 48 hours, matching the spec ("In the IPFS DHT the Expiration Interval is set to 48 hours")
+        /// and go's `DefaultProvideValidity = 48 * time.Hour`.
+        let providerRecordTTL: TimeInterval = 48 * 60 * 60
 
         /// Cadence at which we re-publish our own provider records.
-        /// Half the TTL by libp2p convention — gives a one-round-trip
-        /// margin if a re-publish fails.
-        let providerRecordRepublishInterval: TimeInterval = 12 * 60 * 60
+        ///
+        /// 22 hours, matching the spec ("For the IPFS network it is currently set to 22 hours") and
+        /// go's `DefaultReprovideInterval = 22 * time.Hour`. Comfortably inside the 48-hour
+        /// expiry above, so a single missed republish doesn't drop us from other peers' stores.
+        let providerRecordRepublishInterval: TimeInterval = 22 * 60 * 60
 
         /// The event loop that we're operating on...
         public let eventLoop: EventLoop

--- a/Sources/LibP2PKadDHT/Node.swift
+++ b/Sources/LibP2PKadDHT/Node.swift
@@ -1169,7 +1169,9 @@ public enum KadDHT {
             let targetID = KadDHT.Key(key)
             let value = value.toProtobuf()
 
-            return self.dht.updateValue(value, forKey: targetID).flatMap {
+            /// Stamp the local copy only, the outbound `putValue` below is built separately and
+            /// deliberately leaves `timeReceived` empty, matching go's `MakePutRecord`.
+            return self.dht.updateValue(KadDHT.timeStamped(value), forKey: targetID).flatMap {
                 _ -> EventLoopFuture<Bool> in
                 self.logger.notice(
                     "storeNew: stored locally key=\(KadDHT.keyToHumanReadableString(key))"
@@ -1194,15 +1196,12 @@ public enum KadDHT {
                             self.logger.warning(
                                 "Asking the closest \(closestPeers.count) peers to store our value \(value)"
                             )
-                            /// TODO: We need to limit concurrent queries here as well..
-                            //guard let externalAddys = self.network?.externalListeningAddresses, !externalAddys.isEmpty else {
-                            //    return self.eventLoop.makeFailedFuture(Errors.cantPutValueWithoutExternallyDialableAddress)
-                            //}
-                            //let providerInfo = Peer.PeerInfo(id: self.peerID, addresses: externalAddys)
+                            
+                            // Don't set timeReceived on the way out...
                             var record = DHT.Record()
-                            record.key = value.key  //Data(targetID.bytes)
+                            record.key = value.key
                             record.value = value.value
-                            //record.timeReceived = value.timeReceived
+                            
                             return closestPeers.prefix(4).compactMap { peer in
                                 self._sendQuery(.putValue(key: key, record: record), to: peer, on: self.eventLoop)
                                     .flatMapAlways { res -> EventLoopFuture<Bool> in
@@ -1299,7 +1298,6 @@ public enum KadDHT {
         }
 
         /// TODO: We should update this logic to use providers...
-        /// -
         public func getUsingLookupList(_ key: [UInt8]) -> EventLoopFuture<DHTRecord?> {
             self.eventLoop.flatSubmit {
                 let kid = KadDHT.Key(key, keySpace: .xor)
@@ -1579,7 +1577,7 @@ public enum KadDHT {
             let kid = KadDHT.Key(key, keySpace: .xor)
             return self.dht.addKeyIfSpaceOrCloser(
                 key: kid,
-                value: value,
+                value: KadDHT.timeStamped(value),
                 usingValidator: validator,
                 maxStoreSize: self.dhtSize,
                 targetKey: KadDHT.Key(self.peerID, keySpace: .xor)
@@ -1709,15 +1707,25 @@ extension KadDHT.Node {
 }
 
 extension KadDHT {
-    static public func createPubKeyRecord(peerID: PeerID) throws -> DHTRecord {
-        let df = ISO8601DateFormatter()
-        df.formatOptions.insert(.withFractionalSeconds)
+    /// Returns `record` with `timeReceived` set to now.
+    ///
+    /// `timeReceived` is the receiver's note of when it took delivery, not a publisher-supplied
+    /// field. go's `record.MakePutRecord` builds outbound records with only `Key` and `Value` set and
+    /// deliberately leaves `TimeReceived` empty. The field exists so whoever holds a record can age it
+    /// out against `MaxRecordAge`. So it gets stamped whenever a record enters our store and left blank on
+    /// the way out.
+    static func timeStamped(_ record: DHT.Record) -> DHT.Record {
+        var stamped = record
+        stamped.timeReceived = RFC3339Date().string
+        return stamped
+    }
 
+    static public func createPubKeyRecord(peerID: PeerID) throws -> DHTRecord {
         let key = "/pk/".bytes + peerID.id
         let record = try DHT.Record.with { rec in
             rec.key = Data(key)
             rec.value = try Data(peerID.marshalPublicKey())
-            rec.timeReceived = df.string(from: Date())
+            rec.timeReceived = RFC3339Date().string
         }
 
         return record

--- a/Sources/LibP2PKadDHT/Node.swift
+++ b/Sources/LibP2PKadDHT/Node.swift
@@ -1196,12 +1196,12 @@ public enum KadDHT {
                             self.logger.warning(
                                 "Asking the closest \(closestPeers.count) peers to store our value \(value)"
                             )
-                            
+
                             // Don't set timeReceived on the way out...
                             var record = DHT.Record()
                             record.key = value.key
                             record.value = value.value
-                            
+
                             return closestPeers.prefix(4).compactMap { peer in
                                 self._sendQuery(.putValue(key: key, record: record), to: peer, on: self.eventLoop)
                                     .flatMapAlways { res -> EventLoopFuture<Bool> in

--- a/Sources/LibP2PKadDHT/Utilities/EventLoopDictionary.swift
+++ b/Sources/LibP2PKadDHT/Utilities/EventLoopDictionary.swift
@@ -121,12 +121,22 @@ extension EventLoopDictionary where Key == KadDHT.Key, Value == DHT.Record {
     ) -> EventLoopFuture<EventLoopDictionary.StoreResult> {
         self.eventLoop.submit {
             if let existingRecord = self.store[kid] {
-                /// Store the best record...
+                /// We have an existing record for this key, lets make sure we keep the best one...
                 let values = [existingRecord, value].compactMap { try? $0.serializedData().byteArray }
-                let bestIndex = (try? validator.select(key: kid.original, values: values)) ?? 0
-                let best = (try? DHT.Record(serializedBytes: values[bestIndex])) ?? existingRecord
 
-                /// Update the value...
+                let best: DHT.Record
+                if values.isEmpty {
+                    best = existingRecord
+                } else {
+                    /// ask the validator for the index of the best record
+                    let selected = (try? validator.select(key: kid.original, values: values)) ?? 0
+                    /// ensure the index is valid for our values
+                    let bestIndex = values.indices.contains(selected) ? selected : 0
+                    /// set the best record
+                    best = (try? DHT.Record(serializedBytes: values[bestIndex])) ?? existingRecord
+                }
+
+                /// Update the store with the best record...
                 self.store[kid] = best
                 return best == existingRecord ? .alreadyExists : .updatedValue
 

--- a/Sources/LibP2PKadDHT/Utilities/RFC3339Date.swift
+++ b/Sources/LibP2PKadDHT/Utilities/RFC3339Date.swift
@@ -14,92 +14,194 @@
 
 import Foundation
 
+/// An RFC3339 timestamp, wire-compatible with the `timeReceived` field go writes onto `DHT.Record`.
+///
+/// go emits `util.FormatRFC3339(t)`, which is `t.UTC().Format(time.RFC3339Nano)`.
+///
+/// 1. `RFC3339Nano` omits trailing zeros in the fractional-seconds component. The fraction is
+///    therefore 0–9 digits wide, or can be completely absent
+/// 2. The timezone is always UTC
+///
+/// - Note: Whole seconds and the fractional part are stored separately rather than folded into a single
+/// `Date`. `Date` is a `Double`, so around the present epoch it can only resolve a few hundred
+/// nanoseconds — not enough to order two records emitted in the same microsecond. Comparison uses
+/// the exact `(wholeSeconds, nanoseconds)` pair instead.
 struct RFC3339Date: Equatable, Comparable {
-    private static let strFormat: String = "yyyy-MM-dd'T'HH:mm:ss.SSSSSSSSS'Z'"
+    /// Whole-second portion of the layout. The fraction and zone are handled separately.
+    private static let strFormat: String = "yyyy-MM-dd'T'HH:mm:ss"
     private static let locale: Locale = Locale(identifier: "en_US_POSIX")
     private static let formatter: DateFormatter = {
-        //print("RFC3339Date Initializing Date Formatter")
         let f = DateFormatter()
         f.locale = RFC3339Date.locale
         f.dateFormat = RFC3339Date.strFormat
+        /// Without this, a trailing `Z` is interpreted as local time.
+        f.timeZone = TimeZone(secondsFromGMT: 0)
         return f
     }()
 
-    /// The original RFC3339 String that was parsed if available
-    private var originalString: String?
-    public private(set) var date: Date
+    private static let nanosecondsPerSecond: Int = 1_000_000_000
+
+    /// The original RFC3339 string that was parsed, if any.
+    ///
+    /// Retained so `string` round-trips byte-for-byte.
+    private let originalString: String?
+
+    /// The instant truncated to whole seconds.
+    private let wholeSeconds: Date
+
+    /// The fractional part, in nanoseconds. Always `0..<1_000_000_000`.
+    private let nanos: Int
+
+    /// The full instant, fraction included.
+    ///
+    /// - Warning: Lossy above ~microsecond resolution.
+    ///   Use `==` / `<` for ordering rather than comparing `date` values.
+    public var date: Date {
+        self.wholeSeconds.addingTimeInterval(Double(self.nanos) / Double(Self.nanosecondsPerSecond))
+    }
+
+    public var nanoseconds: Int? {
+        self.nanos
+    }
+
     public var string: String {
         self.originalString ?? self.toString()
     }
 
-    public var nanoseconds: Int? {
-        Calendar.current.dateComponents([.nanosecond], from: self.date).nanosecond
-    }
-
-    /// The Stored Date Formatter
-    //private let formatter:DateFormatter
-
     public init(string: String) throws {
-        guard let date = RFC3339Date.formatter.date(from: string) else {
-            throw NSError(domain: "Invalid RFC3339 Date String", code: 0)
-        }
-
-        let nanoString = string[string.lastIndex(of: ".")!...].dropFirst().dropLast()
-        guard nanoString.count == 9 else { throw NSError(domain: "Invalid RFC3339 Date String", code: 0) }
-
+        let (wholeSeconds, nanos) = try Self.parse(string)
         self.originalString = string
-        self.date = date
-        if let nano = Int(nanoString),
-            let date = Calendar.current.date(bySetting: .nanosecond, value: nano, of: self.date)
-        {
-            self.date = date
-        }
+        self.wholeSeconds = wholeSeconds
+        self.nanos = nanos
     }
 
     public init() {
-        self.originalString = nil
-        self.date = Date()
+        self.init(date: Date())
     }
 
     public init(date: Date) {
         self.originalString = nil
-        self.date = date
+        /// Split the instant into whole seconds and a nanosecond remainder.
+        let interval = date.timeIntervalSince1970
+        let whole = interval.rounded(.down)
+        self.wholeSeconds = Date(timeIntervalSince1970: whole)
+        let fraction = interval - whole
+        /// keeps the remainder non-negative for pre-1970 dates.
+        self.nanos = min(
+            Self.nanosecondsPerSecond - 1,
+            max(0, Int((fraction * Double(Self.nanosecondsPerSecond)).rounded(.down)))
+        )
     }
 
-    private func toString() -> String {
-        var string = RFC3339Date.formatter.string(from: self.date)
-        if let nano = nanoseconds {
-            string = String(string.dropLast(10))
-            string += "\(nano)Z"
+    /// Parses `yyyy-MM-ddTHH:mm:ss[.fraction](Z|±hh:mm)`.
+    ///
+    /// The fraction is optional and of any width; more than 9 digits is truncated to nanoseconds
+    /// rather than rejected, matching Go's `time.Parse`, which accepts an arbitrary-precision
+    /// fraction and discards sub-nanosecond digits.
+    private static func parse(_ string: String) throws -> (whole: Date, nanos: Int) {
+        /// Strip the zone designator first so it can't be confused with the fraction.
+        let (withoutZone, offsetSeconds) = try Self.splitZone(from: Substring(string), of: string)
+        let (base, nanos) = try Self.splitFraction(from: withoutZone, of: string)
+
+        guard let whole = Self.formatter.date(from: String(base)) else {
+            throw Errors.invalidDateString(string)
         }
-        return string
+
+        /// Rebase onto UTC.
+        return (whole.addingTimeInterval(-Double(offsetSeconds)), nanos)
+    }
+
+    /// Removes the trailing zone designator (`Z` or `±hh:mm`), returning the remaining body and the
+    /// zone's offset from UTC in seconds.
+    ///
+    /// - Parameter string: The full input, used only to build the error.
+    private static func splitZone(
+        from body: Substring,
+        of string: String
+    ) throws -> (body: Substring, offsetSeconds: Int) {
+        if let last = body.last, last == "Z" || last == "z" {
+            return (body.dropLast(), 0)
+        }
+
+        /// A `-` inside the date portion isn't a zone sign; a zone is always the trailing
+        /// `±hh:mm`, i.e. exactly 6 characters.
+        guard let signIndex = body.lastIndex(where: { $0 == "+" || $0 == "-" }),
+            body.distance(from: signIndex, to: body.endIndex) == 6,
+            let magnitude = Self.zoneMagnitudeSeconds(body[body.index(after: signIndex)...])
+        else {
+            /// RFC3339 requires an offset; a naked local timestamp is ambiguous.
+            throw Errors.invalidDateString(string)
+        }
+
+        let offsetSeconds = body[signIndex] == "-" ? -magnitude : magnitude
+        return (body[..<signIndex], offsetSeconds)
+    }
+
+    /// Interprets an unsigned `hh:mm` zone body as a count of seconds, or `nil` if it isn't well formed.
+    private static func zoneMagnitudeSeconds(_ zone: Substring) -> Int? {
+        let parts = zone.split(separator: ":", omittingEmptySubsequences: false)
+        guard parts.count == 2, parts[0].count == 2, parts[1].count == 2,
+            let hours = Int(parts[0]), let minutes = Int(parts[1]),
+            hours < 24, minutes < 60
+        else {
+            return nil
+        }
+        return hours * 3600 + minutes * 60
+    }
+
+    /// Separates the optional fractional-seconds component from a zone-stripped body, returning the
+    /// whole-seconds portion and the fraction in nanoseconds.
+    ///
+    /// - Parameter string: The full input, used only to build the error.
+    private static func splitFraction(
+        from body: Substring,
+        of string: String
+    ) throws -> (base: Substring, nanos: Int) {
+        guard let dot = body.firstIndex(of: ".") else { return (body, 0) }
+
+        let digits = body[body.index(after: dot)...]
+        guard !digits.isEmpty, digits.allSatisfy({ $0.isASCII && $0.isNumber }) else {
+            throw Errors.invalidDateString(string)
+        }
+        /// Right-pad to 9 so "5" means 500ms, and truncate anything finer than a nanosecond.
+        let padded =
+            digits.count >= 9
+            ? String(digits.prefix(9))
+            : String(digits) + String(repeating: "0", count: 9 - digits.count)
+        guard let nanos = Int(padded) else { throw Errors.invalidDateString(string) }
+
+        return (body[..<dot], nanos)
+    }
+
+    /// Formats as `RFC3339Nano` does: trailing zeros trimmed from the fraction, and the `.` dropped
+    /// entirely when the fraction is zero.
+    private func toString() -> String {
+        let base = Self.formatter.string(from: self.wholeSeconds)
+        guard self.nanos > 0 else { return "\(base)Z" }
+
+        var fraction = String(format: "%09d", self.nanos)
+        while fraction.hasSuffix("0") { fraction.removeLast() }
+        return "\(base).\(fraction)Z"
+    }
+
+    enum Errors: Error, CustomStringConvertible {
+        case invalidDateString(String)
+
+        var description: String {
+            switch self {
+            case .invalidDateString(let string): return "Invalid RFC3339 date string '\(string)'"
+            }
+        }
     }
 
     static func == (lhs: RFC3339Date, rhs: RFC3339Date) -> Bool {
-        switch (lhs.originalString, rhs.originalString) {
-        case (.some(let ogL), .some(let ogR)):
-            return ogL == ogR
-        default:
-            return lhs.date == rhs.date
-        }
+        lhs.wholeSeconds == rhs.wholeSeconds && lhs.nanos == rhs.nanos
     }
 
     static func < (lhs: RFC3339Date, rhs: RFC3339Date) -> Bool {
-        switch (lhs.originalString, rhs.originalString) {
-        case (.some(let ogL), .some(let ogR)):
-            guard lhs.date == rhs.date else {
-                return lhs.date < rhs.date
-            }
-            // Parse out the nanoseconds from the original strings and compare them...
-            let nanoLeftString = ogL[ogL.lastIndex(of: ".")!...].dropFirst().dropLast()
-            let nanoLeft = UInt64(nanoLeftString)!
-
-            let nanoRightString = ogR[ogR.lastIndex(of: ".")!...].dropFirst().dropLast()
-            let nanoRight = UInt64(nanoRightString)!
-
-            return nanoLeft < nanoRight
-        default:
-            return lhs.date < rhs.date
+        guard lhs.wholeSeconds == rhs.wholeSeconds else {
+            return lhs.wholeSeconds < rhs.wholeSeconds
         }
+        return lhs.nanos < rhs.nanos
     }
 }

--- a/Sources/LibP2PKadDHT/Validators/Validator.swift
+++ b/Sources/LibP2PKadDHT/Validators/Validator.swift
@@ -122,36 +122,16 @@ extension KadDHT {
             let _ = try PeerID(marshaledPublicKey: Data(record.value))
         }
 
+        /// Every valid value for a `/pk/` key is byte-identical, so there is nothing to choose
+        /// between: `validate` binds the key to the hash of the public key it carries, which means
+        /// any value that passes validation is a good value.
+        ///
+        /// - Note: This mirrors go-libp2p-record's `PublicKeyValidator.Select`
         func select(key: [UInt8], values: [[UInt8]]) throws -> Int {
-            print("🔎 PubKeyValidator::Selecting key `\(key.toHexString())` from \(values.count) values")
-            let records = values.map { try? DHT.Record(serializedBytes: $0) }
-            guard !records.compactMap({ $0 }).isEmpty else {
+            guard !values.isEmpty else {
                 throw NSError(domain: "Validator::No Records to select", code: 0)
             }
-            guard records.count > 1 && records[0] != nil else { return 0 }
-
-            var bestValueIndex: Int = 0
-            var bestValue: DHT.Record?
-            for (index, record) in records.enumerated() {
-                guard let record = record else { continue }
-                guard let newRecord = try? RFC3339Date(string: record.timeReceived) else { continue }
-
-                if let currentBest = bestValue {
-                    guard let currentRecord = try? RFC3339Date(string: currentBest.timeReceived) else { continue }
-                    // If this record is more recent then our currentBest, update our current best!
-                    if newRecord > currentRecord {
-                        bestValue = record
-                        bestValueIndex = index
-                    }
-                } else {
-                    // If we don't have a current best, set it!
-                    bestValue = record
-                    bestValueIndex = index
-                }
-            }
-
-            guard bestValue != nil else { throw NSError(domain: "Validator::Failed to select a valid record", code: 0) }
-            return bestValueIndex
+            return 0
         }
     }
 
@@ -165,36 +145,61 @@ extension KadDHT {
             let _ = try IpnsEntry(serializedBytes: record.value)
         }
 
+        /// Picks the best of several IPNS records: **highest sequence number, then latest validity**.
+        ///
+        /// - Note: The validity tie-break matters in practice: a publisher whose republish interval is
+        /// shorter than its record lifetime re-emits the same sequence number with an updated EOL,
+        /// so on equal sequence the longer-lived record has to win.
         func select(key: [UInt8], values: [[UInt8]]) throws -> Int {
-            print("🔎 IPNSValidator::Selecting key `\(key.toHexString())` from \(values.count) values")
-            let records = values.map { try? DHT.Record(serializedBytes: $0) }
-            guard !records.compactMap({ $0 }).isEmpty else {
-                throw NSError(domain: "Validator::No Records to select", code: 0)
+            let entries = values.map { value -> IpnsEntry? in
+                guard let record = try? DHT.Record(serializedBytes: value),
+                    let entry = try? IpnsEntry(serializedBytes: record.value)
+                else { return nil }
+                return entry
             }
-            guard records.count > 1 && records[0] != nil else { return 0 }
 
-            var bestValueIndex: Int = 0
-            var bestValue: DHT.Record?
-            for (index, record) in records.enumerated() {
-                guard let record = record else { continue }
-                guard let newRecord = try? RFC3339Date(string: record.timeReceived) else { continue }
-
-                if let currentBest = bestValue {
-                    guard let currentRecord = try? RFC3339Date(string: currentBest.timeReceived) else { continue }
-                    // If this record is more recent then our currentBest, update our current best!
-                    if newRecord > currentRecord {
-                        bestValue = record
-                        bestValueIndex = index
-                    }
-                } else {
-                    // If we don't have a current best, set it!
-                    bestValue = record
-                    bestValueIndex = index
+            var bestIndex: Int? = nil
+            for (index, entry) in entries.enumerated() {
+                guard let entry else { continue }
+                guard let currentBest = bestIndex, let best = entries[currentBest] else {
+                    bestIndex = index
+                    continue
+                }
+                /// compare the current best to the next record
+                if Self.isPreferred(entry, over: best) {
+                    /// update the best index if it's prefered
+                    bestIndex = index
                 }
             }
 
-            guard bestValue != nil else { throw NSError(domain: "Validator::Failed to select a valid record", code: 0) }
-            return bestValueIndex
+            guard let bestIndex else {
+                throw NSError(domain: "Validator::No Records to select", code: 0)
+            }
+            return bestIndex
+        }
+
+        /// `true` when `candidate` should win over `current`.
+        private static func isPreferred(_ candidate: IpnsEntry, over current: IpnsEntry) -> Bool {
+            /// Highest sequence numbers wins
+            guard candidate.sequence == current.sequence else {
+                return candidate.sequence > current.sequence
+            }
+
+            /// If they have the same sequence number, prefer the later EOL.
+            /// If the candidate doesn't have an EOL, we prefer the current Record
+            guard let candidateEOL = Self.endOfLife(candidate) else { return false }
+            /// If the candidate does have an EOL and the current record doesn't, we prefer the candidate
+            guard let currentEOL = Self.endOfLife(current) else { return true }
+            /// If they both have EOLs keep the longest living record
+            return candidateEOL > currentEOL
+        }
+
+        /// Parses the `validity` field as an `RFC3339Date` EOL timestamp, or `nil` otherwise
+        private static func endOfLife(_ entry: IpnsEntry) -> RFC3339Date? {
+            guard entry.hasValidity, entry.validityType == .eol,
+                let string = String(data: entry.validity, encoding: .utf8)
+            else { return nil }
+            return try? RFC3339Date(string: string)
         }
     }
 }

--- a/Tests/LibP2PKadDHTTests/ProvideTests.swift
+++ b/Tests/LibP2PKadDHTTests/ProvideTests.swift
@@ -203,14 +203,6 @@ extension LibP2PKadDHTTests {
 
         // MARK: - Helpers
 
-        private func syntheticCID(_ tag: String) throws -> [UInt8] {
-            try CID(
-                version: .v1,
-                codec: .raw,
-                multihash: try Multihash(raw: tag.bytes, hashedWith: .sha2_256)
-            ).rawBuffer
-        }
-
         /// The routing-table key a provider record for `cid` is stored under.
         ///
         /// Provider records are keyed by the CID's *multihash*, not by the raw CID bytes, so that every
@@ -242,21 +234,6 @@ extension LibP2PKadDHTTests {
                 )
             )
             app.servers.use(.tcp(host: "127.0.0.1", port: 0))
-        }
-
-        /// Helper method for configuring a DHT Node for the above tests
-        private func dhtHost(
-            mode: KadDHT.Mode = .client,
-            options: KadDHT.NodeOptions = .default,
-            bootstrapPeers: [PeerInfo] = []
-        ) -> ((Application) async throws -> Void) {
-            { app in
-                app.logger.logLevel = .warning
-                app.security.use(.noise)
-                app.muxers.use(.yamux)
-                app.dht.use(.kadDHT(mode: mode, options: options, bootstrapPeers: bootstrapPeers, autoUpdate: false))
-                app.servers.use(.tcp(host: "127.0.0.1", port: 0))
-            }
         }
     }
 }

--- a/Tests/LibP2PKadDHTTests/ProvideTests.swift
+++ b/Tests/LibP2PKadDHTTests/ProvideTests.swift
@@ -18,6 +18,7 @@ import Foundation
 import LibP2P
 import LibP2PCrypto
 import LibP2PNoise
+import LibP2PTesting
 import LibP2PYAMUX
 import Multihash
 import Testing
@@ -27,7 +28,7 @@ import Testing
 extension LibP2PKadDHTTests {
 
     /// Tests for ``KadDHT.Node/provide(cid:announce:)`` and the related
-    /// provider-record renewal + expiry machinery introduced in Phase 3.0.
+    /// provider-record renewal + expiry machinery
     ///
     /// - Unit-style tests (single-node, no real networking) verify the
     ///   state-machine behaviour: local storage, renewal eligibility,
@@ -38,113 +39,111 @@ extension LibP2PKadDHTTests {
     @Suite("Provide Tests", .serialized)
     final class ProvideTests {
 
-        @Test func testProvideStoresLocallyWithoutAnnounce() throws {
-            let app = try makeApplication()
-            defer { app.shutdown() }
-            try app.start()
-            let node = app.dht.kadDHT
+        @Test func testProvideStoresLocallyWithoutAnnounce() async throws {
+            try await withApp(configure: defaultDHTClientConfig) { app in
+                let node = app.dht.kadDHT
 
-            // Use a deterministic CID derived from short content.
-            let cid = try CID(
-                version: .v1,
-                codec: .raw,
-                multihash: try Multihash(raw: "phase-3.0-test".bytes, hashedWith: .sha2_256)
-            ).rawBuffer
+                // Use a deterministic CID derived from short content.
+                let cid = try CID(
+                    version: .v1,
+                    codec: .raw,
+                    multihash: try Multihash(raw: "phase-3.0-test".bytes, hashedWith: .sha2_256)
+                ).rawBuffer
 
-            // Provide with announce:false so no network RPCs are sent.
-            try node.provide(cid: cid, announce: false).wait()
+                // Provide with announce:false so no network RPCs are sent.
+                try await node.provide(cid: cid, announce: false).get()
 
-            let kid = try providerRoutingKey(cid)
-            let stored = try node.providerStore.getValue(forKey: kid, default: []).wait()
-            #expect(node.localProviderKeys.contains(kid), "localProviderKeys must record the CID")
-            #expect(node.localProviderCIDs[kid] == cid, "localProviderCIDs must preserve the original CID bytes")
-            #expect(stored.count == 1, "providerStore should have exactly our entry; got \(stored.count)")
-            #expect(stored.first?.id == Data(node.peerID.id), "stored provider should be us")
+                let kid = try providerRoutingKey(cid)
+                let stored = try await node.providerStore.getValue(forKey: kid, default: []).get()
+                #expect(node.localProviderKeys.contains(kid), "localProviderKeys must record the CID")
+                #expect(node.localProviderCIDs[kid] == cid, "localProviderCIDs must preserve the original CID bytes")
+                #expect(stored.count == 1, "providerStore should have exactly our entry; got \(stored.count)")
+                #expect(stored.first?.id == Data(node.peerID.id), "stored provider should be us")
 
-            let composite = KadDHT.Node.providerRecordKey(kid, peerID: node.peerID)
-            #expect(node.providerRecordAddedAt[composite] != nil, "addedAt should be tracked")
-        }
-
-        @Test func testProvideExpiryPruning() throws {
-            let app = try makeApplication()
-            defer { app.shutdown() }
-            try app.start()
-            let node = app.dht.kadDHT
-
-            // Stage: insert a synthetic provider record for a *foreign*
-            // peer with an obviously-stale addedAt timestamp.
-            let foreignPeerID = try PeerID(.Ed25519)
-            let cid = try syntheticCID("expiry-test")
-            let kid = try providerRoutingKey(cid)
-            let foreignInfo = PeerInfo(peer: foreignPeerID, addresses: [])
-            guard let foreignProvider = try? DHT.Message.Peer(foreignInfo) else {
-                Issue.record("could not encode foreign peer")
-                return
+                let composite = KadDHT.Node.providerRecordKey(kid, peerID: node.peerID)
+                #expect(node.providerRecordAddedAt[composite] != nil, "addedAt should be tracked")
             }
-            try node.providerStore.updateValue([foreignProvider], forKey: kid).wait()
-            let composite = KadDHT.Node.providerRecordKey(kid, peerID: foreignPeerID)
-            node.providerRecordAddedAt[composite] = Date().addingTimeInterval(-25 * 60 * 60)  // 25h ago — past 24h TTL
-
-            // Run expiry; cutoff = now - 24h.
-            let cutoff = Date().addingTimeInterval(-24 * 60 * 60)
-            try node._expireOldProviderRecords(before: cutoff).wait()
-
-            let afterPrune = try node.providerStore.getValue(forKey: kid, default: []).wait()
-            #expect(afterPrune.isEmpty, "expired foreign provider record should be pruned")
-            #expect(node.providerRecordAddedAt[composite] == nil, "stale timestamp entry should be removed")
         }
 
-        @Test func testProvideRenewalEligibility() throws {
-            let app = try makeApplication()
-            defer { app.shutdown() }
-            try app.start()
-            let node = app.dht.kadDHT
+        @Test func testProvideExpiryPruning() async throws {
+            try await withApp(configure: defaultDHTClientConfig) { app in
+                let node = app.dht.kadDHT
 
-            let cid = try syntheticCID("renewal-test")
-            let kid = try providerRoutingKey(cid)
-            // Set up the local record manually so we can manipulate the
-            // addedAt timestamp before kicking the renewal job.
-            try node.provide(cid: cid, announce: false).wait()
-            let composite = KadDHT.Node.providerRecordKey(kid, peerID: node.peerID)
+                // Stage: insert a synthetic provider record for a *foreign*
+                // peer with an obviously-stale addedAt timestamp.
+                let foreignPeerID = try PeerID(.Ed25519)
+                let cid = try syntheticCID("expiry-test")
+                let kid = try providerRoutingKey(cid)
+                let foreignInfo = PeerInfo(peer: foreignPeerID, addresses: [])
+                guard let foreignProvider = try? DHT.Message.Peer(foreignInfo) else {
+                    Issue.record("could not encode foreign peer")
+                    return
+                }
+                let _ = try await node.providerStore.updateValue([foreignProvider], forKey: kid).get()
+                let composite = KadDHT.Node.providerRecordKey(kid, peerID: foreignPeerID)
+                node.providerRecordAddedAt[composite] = Date().addingTimeInterval(-25 * 60 * 60)  // 25h ago — past 24h TTL
 
-            // Backdate beyond the republish interval (12h).
-            let staleTime = Date().addingTimeInterval(-13 * 60 * 60)
-            node.providerRecordAddedAt[composite] = staleTime
+                // Run expiry; cutoff = now - 24h.
+                let cutoff = Date().addingTimeInterval(-24 * 60 * 60)
+                try await node._expireOldProviderRecords(before: cutoff).get()
 
-            // Run the renewal job. With an empty routing table, the
-            // announce path inside the job has no peers to send to, but
-            // the job MUST still refresh our local addedAt timestamp on
-            // completion — otherwise we'd retry on every heartbeat
-            // forever.
-            try node._republishProviderRecords().wait()
-
-            let refreshed = try #require(node.providerRecordAddedAt[composite])
-            #expect(refreshed > staleTime, "renewal job should refresh addedAt past the stale time")
+                let afterPrune = try await node.providerStore.getValue(forKey: kid, default: []).get()
+                #expect(afterPrune.isEmpty, "expired foreign provider record should be pruned")
+                #expect(node.providerRecordAddedAt[composite] == nil, "stale timestamp entry should be removed")
+            }
         }
 
-        @Test func testProvideBeforeBootstrap() throws {
-            let app = try makeApplication()
-            defer { app.shutdown() }
-            try app.start()
-            let node = app.dht.kadDHT
+        @Test func testProvideRenewalEligibility() async throws {
+            try await withApp(configure: defaultDHTClientConfig) { app in
+                let node = app.dht.kadDHT
 
-            let cid = try syntheticCID("before-bootstrap")
-            let kid = try providerRoutingKey(cid)
+                let cid = try syntheticCID("renewal-test")
+                let kid = try providerRoutingKey(cid)
+                // Set up the local record manually so we can manipulate the
+                // addedAt timestamp before kicking the renewal job.
+                try await node.provide(cid: cid, announce: false).get()
+                let composite = KadDHT.Node.providerRecordKey(kid, peerID: node.peerID)
 
-            // Routing table starts empty. provide(announce:true) should
-            // not crash. The iterative lookup finds zero peers; we send
-            // ADD_PROVIDER to zero peers; locally we still record the
-            // CID so a future heartbeat can re-attempt.
-            try node.provide(cid: cid, announce: true).wait()
+                // Backdate past the republish interval so the record is due.
+                //
+                // Derived from the node's own interval rather than hard-coded: this was `-13 * 60 * 60`
+                // against a 12h interval, and silently stopped exercising the renewal path when the
+                // interval moved to go's 22h (`amino.DefaultReprovideInterval`).
+                let staleTime = Date().addingTimeInterval(-(node.providerRecordRepublishInterval + 3600))
+                node.providerRecordAddedAt[composite] = staleTime
 
-            #expect(node.localProviderKeys.contains(kid), "local record should be present even without peers")
-            let stored = try node.providerStore.getValue(forKey: kid, default: []).wait()
-            #expect(stored.count == 1, "local provider entry should exist")
+                // Run the renewal job. With an empty routing table, the
+                // announce path inside the job has no peers to send to, but
+                // the job MUST still refresh our local addedAt timestamp on
+                // completion — otherwise we'd retry on every heartbeat
+                // forever.
+                try await node._republishProviderRecords().get()
+
+                let refreshed = try #require(node.providerRecordAddedAt[composite])
+                #expect(refreshed > staleTime, "renewal job should refresh addedAt past the stale time")
+            }
         }
 
-        @Test func testProvideThenFindRoundTrip() throws {
-            let group = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
-            defer { try! group.syncShutdownGracefully() }
+        @Test func testProvideBeforeBootstrap() async throws {
+            try await withApp(configure: defaultDHTClientConfig) { app in
+                let node = app.dht.kadDHT
+
+                let cid = try syntheticCID("before-bootstrap")
+                let kid = try providerRoutingKey(cid)
+
+                // Routing table starts empty. provide(announce:true) should
+                // not crash. The iterative lookup finds zero peers; we send
+                // ADD_PROVIDER to zero peers; locally we still record the
+                // CID so a future heartbeat can re-attempt.
+                try await node.provide(cid: cid, announce: true).get()
+
+                #expect(node.localProviderKeys.contains(kid), "local record should be present even without peers")
+                let stored = try await node.providerStore.getValue(forKey: kid, default: []).get()
+                #expect(stored.count == 1, "local provider entry should exist")
+            }
+        }
+
+        @Test func testProvideThenFindRoundTrip() async throws {
             let dhtParams = KadDHT.NodeOptions(
                 connectionTimeout: .milliseconds(500),
                 maxConcurrentConnections: 3,
@@ -153,38 +152,25 @@ extension LibP2PKadDHTTests {
                 maxKeyValueStoreEntries: 10,
                 supportLocalNetwork: true
             )
-            let nodeA = try makeHost(
-                mode: .server,
-                options: dhtParams,
-                bootstrapPeers: [],
-                usingGroup: .shared(group)
-            )
-            let nodeB = try makeHost(
-                mode: .server,
-                options: dhtParams,
-                bootstrapPeers: [nodeA.peerInfo],
-                usingGroup: .shared(group)
-            )
-            try nodeA.start()
-            try nodeB.start()
-            defer {
-                nodeA.shutdown()
-                nodeB.shutdown()
+            try await withApp(configure: dhtHost(mode: .server, options: dhtParams, bootstrapPeers: [])) { nodeA in
+                try await withApp(
+                    configure: dhtHost(mode: .server, options: dhtParams, bootstrapPeers: [nodeA.peerInfo])
+                ) { nodeB in
+                    // NodeA creates and provides a CID
+                    let cid = try syntheticCID("integration-round-trip")
+                    try await nodeA.dht.kadDHT.provide(cid: cid, announce: true).get()
+
+                    // Give the network a moment to settle.
+                    try await Task.sleep(for: .milliseconds(25))
+
+                    // NodeB should be able to find providers for the given CID
+                    let providers = try await nodeB.dht.kadDHT.findProviders(cid: cid, count: 4).get()
+                    #expect(!providers.isEmpty, "node B should have found at least one provider for the CID")
+                }
             }
-
-            let cid = try syntheticCID("integration-round-trip")
-            try nodeA.dht.kadDHT.provide(cid: cid, announce: true).wait()
-
-            // Give the network a moment to settle.
-            Thread.sleep(forTimeInterval: 0.5)
-
-            let providers = try nodeB.dht.kadDHT.findProviders(cid: cid, count: 4).wait()
-            #expect(!providers.isEmpty, "node B should have found at least one provider for the CID")
         }
 
-        @Test func testProvideMultipleKeys() throws {
-            let group = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
-            defer { try! group.syncShutdownGracefully() }
+        @Test func testProvideMultipleKeys() async throws {
             let dhtParams = KadDHT.NodeOptions(
                 connectionTimeout: .milliseconds(500),
                 maxConcurrentConnections: 3,
@@ -193,34 +179,25 @@ extension LibP2PKadDHTTests {
                 maxKeyValueStoreEntries: 10,
                 supportLocalNetwork: true
             )
-            let nodeA = try makeHost(
-                mode: .server,
-                options: dhtParams,
-                bootstrapPeers: [],
-                usingGroup: .shared(group)
-            )
-            let nodeB = try makeHost(
-                mode: .server,
-                options: dhtParams,
-                bootstrapPeers: [nodeA.peerInfo],
-                usingGroup: .shared(group)
-            )
-            try nodeA.start()
-            try nodeB.start()
-            defer {
-                nodeA.shutdown()
-                nodeB.shutdown()
-            }
+            try await withApp(configure: dhtHost(mode: .server, options: dhtParams, bootstrapPeers: [])) { nodeA in
+                try await withApp(
+                    configure: dhtHost(mode: .server, options: dhtParams, bootstrapPeers: [nodeA.peerInfo])
+                ) { nodeB in
+                    // NodeA creates and provides multiple CIDs
+                    let cids = try ["key-one", "key-two", "key-three"].map { try syntheticCID($0) }
+                    for cid in cids {
+                        try await nodeA.dht.kadDHT.provide(cid: cid, announce: true).get()
+                    }
 
-            let cids = try ["key-one", "key-two", "key-three"].map { try syntheticCID($0) }
-            for cid in cids {
-                try nodeA.dht.kadDHT.provide(cid: cid, announce: true).wait()
-            }
-            Thread.sleep(forTimeInterval: 0.5)
+                    // Give the network a moment to settle.
+                    try await Task.sleep(for: .milliseconds(25))
 
-            for cid in cids {
-                let providers = try nodeB.dht.kadDHT.findProviders(cid: cid, count: 4).wait()
-                #expect(!providers.isEmpty, "node B should have found a provider for one of the CIDs")
+                    // NodeB should be able to find providers for each of the given CIDs
+                    for cid in cids {
+                        let providers = try await nodeB.dht.kadDHT.findProviders(cid: cid, count: 4).get()
+                        #expect(!providers.isEmpty, "node B should have found a provider for cid \(cid)")
+                    }
+                }
             }
         }
 
@@ -244,12 +221,12 @@ extension LibP2PKadDHTTests {
             KadDHT.Key(try CID(cid).multihash.value, keySpace: .xor)
         }
 
-        private func makeApplication() throws -> Application {
-            let lib = try Application(.testing, peerID: PeerID(.Ed25519), eventLoopGroupProvider: .singleton)
-            lib.logger.logLevel = .warning
-            lib.security.use(.noise)
-            lib.muxers.use(.yamux)
-            lib.dht.use(
+        /// Default app configuration for a DHT Client suitable for the above tests
+        var defaultDHTClientConfig: ((Application) async throws -> Void) = { app in
+            app.logger.logLevel = .warning
+            app.security.use(.noise)
+            app.muxers.use(.yamux)
+            app.dht.use(
                 .kadDHT(
                     mode: .client,
                     options: KadDHT.NodeOptions(
@@ -264,28 +241,22 @@ extension LibP2PKadDHTTests {
                     autoUpdate: false
                 )
             )
-            lib.servers.use(.tcp(host: "127.0.0.1", port: self.nextPort))
-            self.nextPort += 1
-            return lib
+            app.servers.use(.tcp(host: "127.0.0.1", port: 0))
         }
 
-        private var nextPort: Int = 11000
-
-        private func makeHost(
+        /// Helper method for configuring a DHT Node for the above tests
+        private func dhtHost(
             mode: KadDHT.Mode = .client,
             options: KadDHT.NodeOptions = .default,
-            bootstrapPeers: [PeerInfo] = [],
-            usingGroup: Application.EventLoopGroupProvider = .singleton
-        ) throws -> Application {
-            let lib = try Application(.testing, peerID: PeerID(.Ed25519), eventLoopGroupProvider: usingGroup)
-            lib.logger.logLevel = .warning
-            lib.security.use(.noise)
-            lib.muxers.use(.yamux)
-            lib.dht.use(.kadDHT(mode: mode, options: options, bootstrapPeers: bootstrapPeers, autoUpdate: false))
-            lib.servers.use(.tcp(host: "127.0.0.1", port: self.nextPort))
-            self.nextPort += 1
-            return lib
+            bootstrapPeers: [PeerInfo] = []
+        ) -> ((Application) async throws -> Void) {
+            { app in
+                app.logger.logLevel = .warning
+                app.security.use(.noise)
+                app.muxers.use(.yamux)
+                app.dht.use(.kadDHT(mode: mode, options: options, bootstrapPeers: bootstrapPeers, autoUpdate: false))
+                app.servers.use(.tcp(host: "127.0.0.1", port: 0))
+            }
         }
     }
-
 }

--- a/Tests/LibP2PKadDHTTests/ProvideTests.swift
+++ b/Tests/LibP2PKadDHTTests/ProvideTests.swift
@@ -81,7 +81,8 @@ extension LibP2PKadDHTTests {
                 }
                 let _ = try await node.providerStore.updateValue([foreignProvider], forKey: kid).get()
                 let composite = KadDHT.Node.providerRecordKey(kid, peerID: foreignPeerID)
-                node.providerRecordAddedAt[composite] = Date().addingTimeInterval(-25 * 60 * 60)  // 25h ago — past 24h TTL
+                // 25h ago — past 24h TTL
+                node.providerRecordAddedAt[composite] = Date().addingTimeInterval(-25 * 60 * 60)
 
                 // Run expiry; cutoff = now - 24h.
                 let cutoff = Date().addingTimeInterval(-24 * 60 * 60)

--- a/Tests/LibP2PKadDHTTests/RecordTests.swift
+++ b/Tests/LibP2PKadDHTTests/RecordTests.swift
@@ -1,0 +1,294 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the swift-libp2p open source project
+//
+// Copyright (c) 2022-2025 swift-libp2p project authors
+// Licensed under MIT
+//
+// See LICENSE for license information
+// See CONTRIBUTORS for the list of swift-libp2p project authors
+//
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+import CryptoSwift
+import Foundation
+import LibP2P
+import LibP2PCrypto
+import Testing
+
+@testable import LibP2PKadDHT
+
+extension LibP2PKadDHTTests {
+
+    /// Timestamp parsing/formatting for `DHT.Record.timeReceived`.
+    ///
+    /// go writes this field with `util.FormatRFC3339(t)` = `t.UTC().Format(time.RFC3339Nano)`.
+    /// `RFC3339Nano` trims trailing zeros from the fractional-seconds component, so the fraction is
+    /// 0–9 digits wide and is omitted entirely on a whole second.
+    @Suite("RFC3339Date Tests", .serialized)
+    struct RFC3339DateTests {
+
+        @Test(arguments: [
+            "2022-09-12T14:46:52.892973042Z",  // 9 — full nanosecond precision
+            "2022-09-12T14:46:52.892973Z",  // 6
+            "2022-09-12T14:46:52.892Z",  // 3
+            "2022-09-12T14:46:52.8Z",  // 1
+            "2022-09-12T14:46:52Z",  // 0 — whole second, no '.'
+        ])
+        func parsesEveryFractionalWidthGoEmits(_ timestamp: String) throws {
+            let parsed = try RFC3339Date(string: timestamp)
+            /// A parsed timestamp round-trips byte-for-byte, so a record we forward is unchanged.
+            #expect(parsed.string == timestamp)
+        }
+
+        @Test func truncatesSubNanosecondPrecision() throws {
+            let parsed = try RFC3339Date(string: "2022-09-12T14:46:52.892973042123Z")
+            #expect(parsed.nanoseconds == 892_973_042)
+        }
+
+        @Test(arguments: [
+            "2022-09-12T14:46:52.Z",  // bare trailing dot
+            "2022-09-12T14:46:52",  // no zone designator — ambiguous instant
+            "2022-09-12T14:46:52.abcZ",  // non-numeric fraction
+            "2022-09-12T14:46:52.892973042+99:00",  // out-of-range offset
+            "not-a-date",
+        ])
+        func rejectsMalformedStrings(_ timestamp: String) throws {
+            #expect(throws: (any Error).self) { try RFC3339Date(string: timestamp) }
+        }
+
+        @Test func parsesAsUTCRegardlessOfHostTimeZone() throws {
+            let parsed = try RFC3339Date(string: "2022-09-12T14:46:52Z")
+            #expect(parsed.date.timeIntervalSince1970 == 1_662_994_012)
+        }
+
+        @Test func zoneOffsetsNormalizeToTheSameInstant() throws {
+            let utc = try RFC3339Date(string: "2022-09-12T14:46:52Z")
+            let minusFive = try RFC3339Date(string: "2022-09-12T09:46:52-05:00")
+            let plusOneThirty = try RFC3339Date(string: "2022-09-12T16:16:52+01:30")
+            #expect(utc == minusFive)
+            #expect(utc == plusOneThirty)
+        }
+
+        @Test func ordersAcrossFractionalWidths() throws {
+            let whole = try RFC3339Date(string: "2022-09-12T14:46:52Z")
+            let tenth = try RFC3339Date(string: "2022-09-12T14:46:52.1Z")
+            let fifth = try RFC3339Date(string: "2022-09-12T14:46:52.2Z")
+            let nextSecond = try RFC3339Date(string: "2022-09-12T14:46:53Z")
+
+            #expect(whole < tenth)
+            #expect(tenth < fifth)
+            #expect(fifth < nextSecond)
+
+            /// `.1` and `.100000000` are the same instant written two ways.
+            #expect(tenth == (try RFC3339Date(string: "2022-09-12T14:46:52.100000000Z")))
+        }
+
+        /// Nanosecond-resolution ordering must survive; `Date` is a `Double` and can't resolve this
+        /// on its own near the present epoch, which is why the type stores nanos separately.
+        @Test func ordersAtNanosecondResolution() throws {
+            let lower = try RFC3339Date(string: "2022-09-12T14:46:52.892973041Z")
+            let middle = try RFC3339Date(string: "2022-09-12T14:46:52.892973042Z")
+            let upper = try RFC3339Date(string: "2022-09-12T14:46:52.892973043Z")
+
+            #expect(lower < middle)
+            #expect(middle < upper)
+            #expect(middle == (try RFC3339Date(string: "2022-09-12T14:46:52.892973042Z")))
+        }
+
+        /// Our encoder must produce something go would produce — and that we can read back.
+        @Test func emitsRFC3339NanoShapeAndReparses() throws {
+            /// Whole second: no fractional component and no '.' at all.
+            let whole = RFC3339Date(date: Date(timeIntervalSince1970: 1_662_993_612))
+            #expect(whole.string == "2022-09-12T14:40:12Z")
+
+            /// Half second: trailing zeros trimmed, so ".5" rather than ".500000000".
+            let half = RFC3339Date(date: Date(timeIntervalSince1970: 1_662_993_612.5))
+            #expect(half.string == "2022-09-12T14:40:12.5Z")
+
+            /// Anything we emit, we can parse.
+            for emitted in [whole, half] {
+                #expect(try RFC3339Date(string: emitted.string) == emitted)
+            }
+        }
+
+        @Test func pubKeyRecordTimestampIsSelfParseable() throws {
+            let record = try KadDHT.createPubKeyRecord(peerID: PeerID(.Ed25519)).toProtobuf()
+            #expect(!record.timeReceived.isEmpty)
+            #expect(throws: Never.self) { try RFC3339Date(string: record.timeReceived) }
+        }
+    }
+
+    /// Record selection, and the bounds-safety of the code that consumes a `Validator`'s index.
+    @Suite("Record Selection Tests", .serialized)
+    struct RecordSelectionTests {
+
+        // MARK: - /pk/
+
+        /// go-libp2p-record's `PublicKeyValidator.Select` is `return 0, nil` — "It always returns 0
+        /// as all public keys are equivalently valid." Once `validate` binds the key to the hash of
+        /// the public key, every value that validates is the same value.
+        @Test func pubKeySelectAlwaysReturnsZero() throws {
+            let validator = KadDHT.PubKeyValidator()
+            let a = try KadDHT.createPubKeyRecord(peerID: PeerID(.Ed25519)).toProtobuf().serializedData()
+                .byteArray
+            let b = try KadDHT.createPubKeyRecord(peerID: PeerID(.Ed25519)).toProtobuf().serializedData()
+                .byteArray
+
+            #expect(try validator.select(key: "/pk/".bytes, values: [a, b]) == 0)
+            #expect(try validator.select(key: "/pk/".bytes, values: [b, a]) == 0)
+        }
+
+        @Test func pubKeySelectThrowsOnEmptyInput() throws {
+            #expect(throws: (any Error).self) {
+                try KadDHT.PubKeyValidator().select(key: "/pk/".bytes, values: [])
+            }
+        }
+
+        // MARK: - /ipns/
+
+        @Test func ipnsSelectPrefersHigherSequence() throws {
+            let older = try ipnsRecord(sequence: 4, validity: "2030-01-01T00:00:00Z")
+            let newer = try ipnsRecord(sequence: 7, validity: "2030-01-01T00:00:00Z")
+
+            let validator = KadDHT.IPNSValidator()
+            #expect(try validator.select(key: "/ipns/".bytes, values: [older, newer]) == 1)
+            #expect(try validator.select(key: "/ipns/".bytes, values: [newer, older]) == 0)
+        }
+
+        /// When the sequence number is equal the later EOL wins. This is the real-world case where a
+        /// publisher whose republish interval is shorter than its record lifetime re-emits the same
+        /// sequence with a nearer EOL, the longer-lived record has to survive.
+        @Test func ipnsSelectBreaksSequenceTiesOnLaterValidity() throws {
+            let shortLived = try ipnsRecord(sequence: 9, validity: "2027-01-01T00:00:00Z")
+            let longLived = try ipnsRecord(sequence: 9, validity: "2027-01-01T00:00:00.1Z")
+
+            let validator = KadDHT.IPNSValidator()
+            #expect(try validator.select(key: "/ipns/".bytes, values: [shortLived, longLived]) == 1)
+            #expect(try validator.select(key: "/ipns/".bytes, values: [longLived, shortLived]) == 0)
+        }
+
+        /// `timeReceived` is our own local timestamp, it should carry no weight in record sorting
+        @Test func ipnsSelectIgnoresTimeReceived() throws {
+            /// Lower sequence but stamped far in the future; the higher sequence must still win.
+            let lowSeqFreshStamp = try ipnsRecord(
+                sequence: 1,
+                validity: "2030-01-01T00:00:00Z",
+                timeReceived: "2035-01-01T00:00:00Z"
+            )
+            let highSeqOldStamp = try ipnsRecord(
+                sequence: 2,
+                validity: "2030-01-01T00:00:00Z",
+                timeReceived: "2020-01-01T00:00:00Z"
+            )
+
+            let validator = KadDHT.IPNSValidator()
+            #expect(try validator.select(key: "/ipns/".bytes, values: [lowSeqFreshStamp, highSeqOldStamp]) == 1)
+        }
+
+        @Test func ipnsSelectSkipsUnparseableLeadingValue() throws {
+            let valid = try ipnsRecord(sequence: 3, validity: "2030-01-01T00:00:00Z")
+            let garbage: [UInt8] = [0xff, 0xff, 0xff, 0xff]
+
+            let chosen = try KadDHT.IPNSValidator().select(key: "/ipns/".bytes, values: [garbage, valid])
+            #expect(chosen == 1, "must skip the unparseable value rather than returning index 0")
+        }
+
+        @Test func ipnsSelectThrowsWhenNothingParses() throws {
+            #expect(throws: (any Error).self) {
+                try KadDHT.IPNSValidator().select(key: "/ipns/".bytes, values: [[0xff], [0xfe]])
+            }
+        }
+
+        @Test(arguments: [-1, 2, 99, Int.max])
+        func storeSurvivesOutOfRangeSelectIndex(_ rogueIndex: Int) throws {
+            let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+            defer { try! group.syncShutdownGracefully() }
+            let loop = group.next()
+
+            let store = EventLoopDictionary(key: KadDHT.Key.self, value: DHT.Record.self, on: loop)
+            let kid = KadDHT.Key("/pk/test".bytes, keySpace: .xor)
+
+            let existing = DHT.Record.with {
+                $0.key = Data("/pk/test".bytes)
+                $0.value = Data("original".utf8)
+            }
+            try store.updateValue(existing, forKey: kid).wait()
+
+            let incoming = DHT.Record.with {
+                $0.key = Data("/pk/test".bytes)
+                $0.value = Data("replacement".utf8)
+            }
+
+            let rogue = KadDHT.BaseValidator(
+                validationFunction: { _, _ in },
+                selectFunction: { _, _ in rogueIndex }
+            )
+
+            /// The rogue validator yields an invalid index, ensure we handle it correctly without erroring
+            let result = try store.addKeyIfSpaceOrCloser(
+                key: kid,
+                value: incoming,
+                usingValidator: rogue,
+                maxStoreSize: 10,
+                targetKey: KadDHT.Key("self".bytes, keySpace: .xor)
+            ).wait()
+            _ = result
+
+            let stored = try store.getValue(forKey: kid).wait()
+            #expect(stored != nil)
+            #expect(stored == existing)
+        }
+
+        // MARK: - Helpers
+
+        /// Builds an unsigned serialized `DHT.Record` wrapping an `IpnsEntry`.
+        ///
+        /// Only the fields that selection reads are populated.
+        private func ipnsRecord(
+            sequence: UInt64,
+            validity: String,
+            timeReceived: String = "2024-01-01T00:00:00Z"
+        ) throws -> [UInt8] {
+            let entry = IpnsEntry.with {
+                $0.value = Data("/ipfs/bafyfoo".utf8)
+                $0.sequence = sequence
+                $0.validityType = .eol
+                $0.validity = Data(validity.utf8)
+            }
+            let record = DHT.Record.with {
+                $0.key = Data("/ipns/".bytes)
+                $0.value = (try? entry.serializedData()) ?? Data()
+                $0.timeReceived = timeReceived
+            }
+            return try record.serializedData().byteArray
+        }
+    }
+
+    @Suite("Provider Interval Tests", .serialized)
+    struct ProviderIntervalTests {
+
+        /// Spec: "In the IPFS DHT the Expiration Interval is set to 48 hours" /
+        /// "For the IPFS network it is currently set to 22 hours".
+        /// go: `DefaultProvideValidity = 48 * time.Hour`, `DefaultReprovideInterval = 22 * time.Hour`.
+        @Test func matchesGoProviderLifetimes() async throws {
+            let app = try await Application.make(.testing, peerID: .ephemeral(type: .Ed25519))
+            app.logger.logLevel = .warning
+            app.security.use(.noise)
+            app.muxers.use(.yamux)
+            app.dht.use(.kadDHT(mode: .client, options: .default, bootstrapPeers: [], autoUpdate: false))
+
+            let node = app.dht.kadDHT
+            #expect(node.providerRecordTTL == 48 * 60 * 60)
+            #expect(node.providerRecordRepublishInterval == 22 * 60 * 60)
+
+            /// The republish cadence must leave slack before expiry, or a single missed renewal drops
+            /// us out of remote stores.
+            #expect(node.providerRecordRepublishInterval < node.providerRecordTTL)
+            
+            try await app.asyncShutdown()
+        }
+    }
+}

--- a/Tests/LibP2PKadDHTTests/RecordTests.swift
+++ b/Tests/LibP2PKadDHTTests/RecordTests.swift
@@ -83,7 +83,7 @@ extension LibP2PKadDHTTests {
             #expect(fifth < nextSecond)
 
             /// `.1` and `.100000000` are the same instant written two ways.
-            #expect(tenth == (try RFC3339Date(string: "2022-09-12T14:46:52.100000000Z")))
+            #expect(tenth == (try? RFC3339Date(string: "2022-09-12T14:46:52.100000000Z")))
         }
 
         /// Nanosecond-resolution ordering must survive; `Date` is a `Double` and can't resolve this
@@ -95,7 +95,7 @@ extension LibP2PKadDHTTests {
 
             #expect(lower < middle)
             #expect(middle < upper)
-            #expect(middle == (try RFC3339Date(string: "2022-09-12T14:46:52.892973042Z")))
+            #expect(middle == (try? RFC3339Date(string: "2022-09-12T14:46:52.892973042Z")))
         }
 
         /// Our encoder must produce something go would produce — and that we can read back.
@@ -110,7 +110,7 @@ extension LibP2PKadDHTTests {
 
             /// Anything we emit, we can parse.
             for emitted in [whole, half] {
-                #expect(try RFC3339Date(string: emitted.string) == emitted)
+                #expect((try? RFC3339Date(string: emitted.string)) == emitted)
             }
         }
 
@@ -215,7 +215,7 @@ extension LibP2PKadDHTTests {
                 $0.key = Data("/pk/test".bytes)
                 $0.value = Data("original".utf8)
             }
-            try store.updateValue(existing, forKey: kid).wait()
+            let _ = try store.updateValue(existing, forKey: kid).wait()
 
             let incoming = DHT.Record.with {
                 $0.key = Data("/pk/test".bytes)

--- a/Tests/LibP2PKadDHTTests/RecordTests.swift
+++ b/Tests/LibP2PKadDHTTests/RecordTests.swift
@@ -287,7 +287,7 @@ extension LibP2PKadDHTTests {
             /// The republish cadence must leave slack before expiry, or a single missed renewal drops
             /// us out of remote stores.
             #expect(node.providerRecordRepublishInterval < node.providerRecordTTL)
-            
+
             try await app.asyncShutdown()
         }
     }

--- a/Tests/LibP2PKadDHTTests/ValueStoreTests.swift
+++ b/Tests/LibP2PKadDHTTests/ValueStoreTests.swift
@@ -17,6 +17,7 @@ import LibP2P
 import LibP2PNoise
 import LibP2PYAMUX
 import Multihash
+import LibP2PTesting
 import Testing
 
 @testable import LibP2PKadDHT
@@ -40,11 +41,7 @@ extension LibP2PKadDHTTests {
     @Suite("Value Store Tests", .serialized)
     final class ValueStoreTests {
 
-        @Test
-        func testStoreNewWithEmptyRoutingTableReturnsTrue() throws {
-            let group = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
-            defer { try! group.syncShutdownGracefully() }
-
+        @Test func testStoreNewWithEmptyRoutingTableReturnsTrue() async throws {
             let dhtParams = KadDHT.NodeOptions(
                 connectionTimeout: .milliseconds(150),
                 maxConcurrentConnections: 3,
@@ -53,37 +50,26 @@ extension LibP2PKadDHTTests {
                 maxKeyValueStoreEntries: 10,
                 supportLocalNetwork: true
             )
-
-            let node = try makeHost(
-                mode: .server,
-                options: dhtParams,
-                bootstrapPeers: [],
-                usingGroup: .shared(group)
-            )
-            try node.start()
-            defer { node.shutdown() }
-
-            let key = try syntheticCID("local-first-empty-rt")
-            let record = TestRecord(
-                key: Data(key),
-                value: Data("hello-local-first".utf8)
-            )
-            let accepted = try node.dht.kadDHT.storeNew(key, value: record).wait()
-            #expect(accepted, "storeNew should accept even with empty routing table")
-
-            // Publisher's own get must succeed without any remote
-            // hop — local-first means the value is sitting in our
-            // own kv store.
-            let fetched = try node.dht.kadDHT.getUsingLookupList(key).wait()
-            #expect(fetched != nil, "publisher's own getUsingLookupList should hit the local kv")
-            #expect(fetched?.value == Data("hello-local-first".utf8))
+            
+            try await withApp(configure: dhtHost(mode: .server, options: dhtParams)) { node in
+                let key = try syntheticCID("local-first-empty-rt")
+                let record = TestRecord(
+                    key: Data(key),
+                    value: Data("hello-local-first".utf8)
+                )
+                let accepted = try await node.dht.kadDHT.storeNew(key, value: record).get()
+                #expect(accepted, "storeNew should accept even with empty routing table")
+                
+                // Publisher's own get must succeed without any remote
+                // hop — local-first means the value is sitting in our
+                // own kv store.
+                let fetched = try await node.dht.kadDHT.getUsingLookupList(key).get()
+                #expect(fetched != nil, "publisher's own getUsingLookupList should hit the local kv")
+                #expect(fetched?.value == Data("hello-local-first".utf8))
+            }
         }
 
-        @Test(.internalIntegrationTestsEnabled)
-        func testStoreNewCrossNodeRoundTrip() throws {
-            let group = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
-            defer { try! group.syncShutdownGracefully() }
-
+        @Test func testStoreNewCrossNodeRoundTrip() async throws {
             let dhtParams = KadDHT.NodeOptions(
                 connectionTimeout: .milliseconds(500),
                 maxConcurrentConnections: 3,
@@ -93,41 +79,21 @@ extension LibP2PKadDHTTests {
                 supportLocalNetwork: true
             )
 
-            let publisher = try makeHost(
-                mode: .server,
-                options: dhtParams,
-                bootstrapPeers: [],
-                usingGroup: .shared(group)
-            )
-            try publisher.start()
+            try await withApp(configure: dhtHost(mode: .server, options: dhtParams)) { publisher in
+                try await withApp(configure: dhtHost(mode: .server, options: dhtParams, bootstrapPeers: [publisher.peerInfo])) { consumer in
+                    let key = try syntheticCID("local-first-cross-node")
+                    let record = TestRecord(
+                        key: Data(key),
+                        value: Data("hello-cross-node".utf8)
+                    )
+                    let stored = try await publisher.dht.kadDHT.storeNew(key, value: record).get()
+                    #expect(stored, "storeNew should accept (local-first semantics)")
 
-            let consumer = try makeHost(
-                mode: .server,
-                options: dhtParams,
-                bootstrapPeers: [publisher.peerInfo],
-                usingGroup: .shared(group)
-            )
-            try consumer.start()
-            defer {
-                publisher.shutdown()
-                consumer.shutdown()
+                    let fetched = try await consumer.dht.kadDHT.getUsingLookupList(key).get()
+                    #expect(fetched != nil, "consumer should fetch publisher's value via iterative lookup")
+                    #expect(fetched?.value == Data("hello-cross-node".utf8))
+                }
             }
-
-            let key = try syntheticCID("local-first-cross-node")
-            let record = TestRecord(
-                key: Data(key),
-                value: Data("hello-cross-node".utf8)
-            )
-            let stored = try publisher.dht.kadDHT.storeNew(key, value: record).wait()
-            #expect(stored, "storeNew should accept (local-first semantics)")
-
-            // Give a moment for the consumer's iterative lookup to
-            // discover the publisher.
-            Thread.sleep(forTimeInterval: 0.5)
-
-            let fetched = try consumer.dht.kadDHT.getUsingLookupList(key).wait()
-            #expect(fetched != nil, "consumer should fetch publisher's value via iterative lookup")
-            #expect(fetched?.value == Data("hello-cross-node".utf8))
         }
 
         // MARK: - Helpers
@@ -140,22 +106,19 @@ extension LibP2PKadDHTTests {
             ).rawBuffer
         }
 
-        private var nextPort: Int = Int.random(in: 13000..<14000)
-
-        private func makeHost(
+        private func dhtHost(
             mode: KadDHT.Mode = .client,
             options: KadDHT.NodeOptions = .default,
             bootstrapPeers: [PeerInfo] = [],
-            usingGroup: Application.EventLoopGroupProvider = .singleton
-        ) throws -> Application {
-            let lib = try Application(.testing, peerID: PeerID(.Ed25519), eventLoopGroupProvider: usingGroup)
-            lib.logger.logLevel = .warning
-            lib.security.use(.noise)
-            lib.muxers.use(.yamux)
-            lib.dht.use(.kadDHT(mode: mode, options: options, bootstrapPeers: bootstrapPeers, autoUpdate: false))
-            lib.servers.use(.tcp(host: "127.0.0.1", port: self.nextPort))
-            self.nextPort += 1
-            return lib
+            logLevel: Logger.Level = .warning
+        ) -> ((Application) async throws -> Void) {
+            { app in
+                app.logger.logLevel = logLevel
+                app.security.use(.noise)
+                app.muxers.use(.yamux)
+                app.dht.use(.kadDHT(mode: mode, options: options, bootstrapPeers: bootstrapPeers, autoUpdate: false))
+                app.servers.use(.tcp(host: "127.0.0.1", port: 0))
+            }
         }
     }
 

--- a/Tests/LibP2PKadDHTTests/ValueStoreTests.swift
+++ b/Tests/LibP2PKadDHTTests/ValueStoreTests.swift
@@ -95,31 +95,6 @@ extension LibP2PKadDHTTests {
                 }
             }
         }
-
-        // MARK: - Helpers
-
-        private func syntheticCID(_ tag: String) throws -> [UInt8] {
-            try CID(
-                version: .v1,
-                codec: .raw,
-                multihash: try Multihash(raw: tag.bytes, hashedWith: .sha2_256)
-            ).rawBuffer
-        }
-
-        private func dhtHost(
-            mode: KadDHT.Mode = .client,
-            options: KadDHT.NodeOptions = .default,
-            bootstrapPeers: [PeerInfo] = [],
-            logLevel: Logger.Level = .warning
-        ) -> ((Application) async throws -> Void) {
-            { app in
-                app.logger.logLevel = logLevel
-                app.security.use(.noise)
-                app.muxers.use(.yamux)
-                app.dht.use(.kadDHT(mode: mode, options: options, bootstrapPeers: bootstrapPeers, autoUpdate: false))
-                app.servers.use(.tcp(host: "127.0.0.1", port: 0))
-            }
-        }
     }
 
     private struct TestRecord: DHTRecord {
@@ -130,4 +105,30 @@ extension LibP2PKadDHTTests {
         let timeReceived: String = ""
     }
 
+}
+
+extension LibP2PKadDHTTests {
+    static func syntheticCID(_ tag: String) throws -> [UInt8] {
+        try CID(
+            version: .v1,
+            codec: .raw,
+            multihash: try Multihash(raw: tag.bytes, hashedWith: .sha2_256)
+        ).rawBuffer
+    }
+    
+    /// Helper method for configuring a DHT Node for the above tests
+    static func dhtHost(
+        mode: KadDHT.Mode = .client,
+        options: KadDHT.NodeOptions = .default,
+        bootstrapPeers: [PeerInfo] = [],
+        logLevel: Logger.Level = .warning
+    ) -> ((Application) async throws -> Void) {
+        { app in
+            app.logger.logLevel = logLevel
+            app.security.use(.noise)
+            app.muxers.use(.yamux)
+            app.dht.use(.kadDHT(mode: mode, options: options, bootstrapPeers: bootstrapPeers, autoUpdate: false))
+            app.servers.use(.tcp(host: "127.0.0.1", port: 0))
+        }
+    }
 }

--- a/Tests/LibP2PKadDHTTests/ValueStoreTests.swift
+++ b/Tests/LibP2PKadDHTTests/ValueStoreTests.swift
@@ -15,9 +15,9 @@
 import CID
 import LibP2P
 import LibP2PNoise
+import LibP2PTesting
 import LibP2PYAMUX
 import Multihash
-import LibP2PTesting
 import Testing
 
 @testable import LibP2PKadDHT
@@ -50,7 +50,7 @@ extension LibP2PKadDHTTests {
                 maxKeyValueStoreEntries: 10,
                 supportLocalNetwork: true
             )
-            
+
             try await withApp(configure: dhtHost(mode: .server, options: dhtParams)) { node in
                 let key = try syntheticCID("local-first-empty-rt")
                 let record = TestRecord(
@@ -59,7 +59,7 @@ extension LibP2PKadDHTTests {
                 )
                 let accepted = try await node.dht.kadDHT.storeNew(key, value: record).get()
                 #expect(accepted, "storeNew should accept even with empty routing table")
-                
+
                 // Publisher's own get must succeed without any remote
                 // hop — local-first means the value is sitting in our
                 // own kv store.
@@ -80,7 +80,9 @@ extension LibP2PKadDHTTests {
             )
 
             try await withApp(configure: dhtHost(mode: .server, options: dhtParams)) { publisher in
-                try await withApp(configure: dhtHost(mode: .server, options: dhtParams, bootstrapPeers: [publisher.peerInfo])) { consumer in
+                try await withApp(
+                    configure: dhtHost(mode: .server, options: dhtParams, bootstrapPeers: [publisher.peerInfo])
+                ) { consumer in
                     let key = try syntheticCID("local-first-cross-node")
                     let record = TestRecord(
                         key: Data(key),
@@ -115,7 +117,7 @@ extension LibP2PKadDHTTests {
             multihash: try Multihash(raw: tag.bytes, hashedWith: .sha2_256)
         ).rawBuffer
     }
-    
+
     /// Helper method for configuring a DHT Node for the above tests
     static func dhtHost(
         mode: KadDHT.Mode = .client,


### PR DESCRIPTION
### What?
This PR focuses on fixing the previous `RFC3339Date` implementation. The new version is compatible with Go's RFC3339Nano format, which includes optional nanoseconds.

### Changes:
- Updated default `Record` TTL and republish intervals to match go-libp2p
- Rewrote the `RFC3339Date` string parser to correctly parse Go style `RFC3339Nano` timestamps
- We no longer set `timeReceived` on outbound `Records`
- We stamp inbound Records using the correct time stamp
- Fixed PubKey and IPNS Validators to properly select the best records
- Updated a Provider and ValueStore tests to use the async await `withApp` test helper